### PR TITLE
Optimize CI pipeline and enable Vercel production deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   NODE_VERSION: '20'
@@ -169,7 +169,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
+        uses: amondnet/vercel-action@v41.1.4
         with:
           vercel-token: ${{ secrets.VERCEL_TOKEN }}
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
   e2e:
     name: E2E Tests
     runs-on: ubuntu-latest
-    needs: test
+    needs: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -97,7 +97,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    needs: [lint, test]
+    needs: lint
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -156,26 +156,22 @@ jobs:
           temporaryPublicStorage: true
         continue-on-error: true
 
-  # Deploy to production (only on main branch push)
-  # TODO: Configure Vercel deployment secrets before enabling
-  # Required secrets: VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID
-  # See CLAUDE.md for setup instructions
-  # deploy:
-  #   name: Deploy
-  #   runs-on: ubuntu-latest
-  #   needs: [build, e2e]
-  #   if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-  #   environment:
-  #     name: production
-  #     url: https://lalding.in
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v4
-  #
-  #     - name: Deploy to Vercel
-  #       uses: amondnet/vercel-action@v25
-  #       with:
-  #         vercel-token: ${{ secrets.VERCEL_TOKEN }}
-  #         vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-  #         vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-  #         vercel-args: '--prod'
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs: [lint, test, e2e, build]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment:
+      name: production
+      url: https://lalding.in
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,10 +110,9 @@ Framer Motion is used throughout for scroll-triggered animations and transitions
 - `feature/*` - Feature branches merged directly to main via PR
 
 **CI/CD**: GitHub Actions (`.github/workflows/ci.yml`)
-
-- Lint → Build pipeline
+- Lint → parallel Build, Test, E2E pipeline
 - Lighthouse CI for performance audits on PRs
-- Deploy job (currently disabled - see TODO below)
+- Automated Vercel production deployment on main (gated behind all CI jobs)
 
 ---
 
@@ -123,23 +122,6 @@ Framer Motion is used throughout for scroll-triggered animations and transitions
 | ---------------------------------------------------------------------------------- | --------------------------------------------- |
 | [`docs/ui-ux-design.md`](docs/ui-ux-design.md)                                     | Comprehensive UI/UX modernization plan        |
 | [`docs/improvements-and-optimizations.md`](docs/improvements-and-optimizations.md) | Known issues and optimization recommendations |
-
----
-
-## TODOs
-
-### CI/CD: Enable Vercel Deployment
-
-The deploy job in `.github/workflows/ci.yml` is currently disabled. To enable automated deployments:
-
-1. Install Vercel CLI: `npm i -g vercel`
-2. Run `vercel link` in the project root to connect to your Vercel project
-3. Get your Vercel token from https://vercel.com/account/tokens
-4. Add these secrets to GitHub repository settings (Settings → Secrets → Actions):
-   - `VERCEL_TOKEN` - Your Vercel API token
-   - `VERCEL_ORG_ID` - Found in `.vercel/project.json` after linking
-   - `VERCEL_PROJECT_ID` - Found in `.vercel/project.json` after linking
-5. Uncomment the deploy job in `.github/workflows/ci.yml`
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ Framer Motion is used throughout for scroll-triggered animations and transitions
 - `feature/*` - Feature branches merged directly to main via PR
 
 **CI/CD**: GitHub Actions (`.github/workflows/ci.yml`)
+
 - Lint → parallel Build, Test, E2E pipeline
 - Lighthouse CI for performance audits on PRs
 - Automated Vercel production deployment on main (gated behind all CI jobs)

--- a/docs/CI-CD-OPTIMIZATIONS.md
+++ b/docs/CI-CD-OPTIMIZATIONS.md
@@ -6,11 +6,11 @@ The CI pipeline at `.github/workflows/ci.yml` has suboptimal job dependencies th
 
 ## Files to Modify
 
-| File | Action | Description |
-|------|--------|-------------|
-| `.github/workflows/ci.yml` | Edit | Fix job dependencies + uncomment deploy job |
-| `vercel.json` | Create | Disable Vercel auto-deploy on main |
-| `CLAUDE.md` | Edit | Remove deployment TODO, update CI/CD description |
+| File                       | Action | Description                                      |
+| -------------------------- | ------ | ------------------------------------------------ |
+| `.github/workflows/ci.yml` | Edit   | Fix job dependencies + uncomment deploy job      |
+| `vercel.json`              | Create | Disable Vercel auto-deploy on main               |
+| `CLAUDE.md`                | Edit   | Remove deployment TODO, update CI/CD description |
 
 ## Step 1: Create feature branch
 
@@ -41,36 +41,36 @@ Wall time: ~6 min (test, e2e, and build run in parallel)
 
 **Changes:**
 
-| Job | Current `needs` | New `needs` | Reason |
-|-----|----------------|-------------|--------|
-| `test` | `lint` | `lint` | Already correct |
-| `e2e` | `test` | `lint` | E2E tests are independent of unit tests |
-| `build` | `[lint, test]` | `lint` | Build only needs lint to pass, not tests |
+| Job     | Current `needs` | New `needs` | Reason                                   |
+| ------- | --------------- | ----------- | ---------------------------------------- |
+| `test`  | `lint`          | `lint`      | Already correct                          |
+| `e2e`   | `test`          | `lint`      | E2E tests are independent of unit tests  |
+| `build` | `[lint, test]`  | `lint`      | Build only needs lint to pass, not tests |
 
 ## Step 3: Uncomment and update deploy job in `ci.yml`
 
 Replace the commented-out deploy block (lines 159–182) with:
 
 ```yaml
-  deploy:
-    name: Deploy to Production
-    runs-on: ubuntu-latest
-    needs: [lint, test, e2e, build]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    environment:
-      name: production
-      url: https://lalding.in
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+deploy:
+  name: Deploy to Production
+  runs-on: ubuntu-latest
+  needs: [lint, test, e2e, build]
+  if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+  environment:
+    name: production
+    url: https://lalding.in
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
 
-      - name: Deploy to Vercel
-        uses: amondnet/vercel-action@v25
-        with:
-          vercel-token: ${{ secrets.VERCEL_TOKEN }}
-          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
-          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
-          vercel-args: '--prod'
+    - name: Deploy to Vercel
+      uses: amondnet/vercel-action@v25
+      with:
+        vercel-token: ${{ secrets.VERCEL_TOKEN }}
+        vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+        vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+        vercel-args: '--prod'
 ```
 
 Key points:

--- a/docs/CI-CD-OPTIMIZATIONS.md
+++ b/docs/CI-CD-OPTIMIZATIONS.md
@@ -1,0 +1,132 @@
+# Plan: Optimize CI Pipeline and Add CD for Vercel Production Deployment
+
+## Context
+
+The CI pipeline at `.github/workflows/ci.yml` has suboptimal job dependencies that serialize work unnecessarily, adding ~4 minutes of wasted wall time. Additionally, the deploy job for Vercel production deployments is commented out. Now that the Vercel secrets (VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID) are configured in the GitHub repo, we can enable automated production deployments gated behind CI.
+
+## Files to Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `.github/workflows/ci.yml` | Edit | Fix job dependencies + uncomment deploy job |
+| `vercel.json` | Create | Disable Vercel auto-deploy on main |
+| `CLAUDE.md` | Edit | Remove deployment TODO, update CI/CD description |
+
+## Step 1: Create feature branch
+
+```bash
+git checkout main && git checkout -b feature/ci-cd-optimization
+```
+
+## Step 2: Fix CI job dependencies in `ci.yml`
+
+**Current dependency graph** (sequential bottleneck):
+
+```
+lint → test → e2e
+lint → test → build → lighthouse
+```
+
+Wall time: ~10 min (test, e2e, and build run sequentially)
+
+**New dependency graph** (parallel after lint):
+
+```
+lint ─┬─→ build ──→ lighthouse (PR only)
+      ├─→ test
+      └─→ e2e
+```
+
+Wall time: ~6 min (test, e2e, and build run in parallel)
+
+**Changes:**
+
+| Job | Current `needs` | New `needs` | Reason |
+|-----|----------------|-------------|--------|
+| `test` | `lint` | `lint` | Already correct |
+| `e2e` | `test` | `lint` | E2E tests are independent of unit tests |
+| `build` | `[lint, test]` | `lint` | Build only needs lint to pass, not tests |
+
+## Step 3: Uncomment and update deploy job in `ci.yml`
+
+Replace the commented-out deploy block (lines 159–182) with:
+
+```yaml
+  deploy:
+    name: Deploy to Production
+    runs-on: ubuntu-latest
+    needs: [lint, test, e2e, build]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    environment:
+      name: production
+      url: https://lalding.in
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod'
+```
+
+Key points:
+
+- `needs: [lint, test, e2e, build]` — gates deploy behind **all** CI jobs
+- `if` condition ensures it only runs on pushes to main (not PRs)
+- Uses `environment: production` with URL for GitHub deployment tracking
+
+## Step 4: Create `vercel.json`
+
+New file at project root:
+
+```json
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}
+```
+
+This disables Vercel's automatic deployment on main pushes (so deploys only happen through our CI/CD pipeline after all gates pass), while keeping PR preview deployments active for other branches.
+
+## Step 5: Update `CLAUDE.md`
+
+**1. Remove the TODOs section** (lines 129–143) — the "CI/CD: Enable Vercel Deployment" TODO with setup instructions, since it's now done. Also remove the `---` separator above it.
+
+**2. Update the CI/CD description** in the Git Workflow section (lines 112–116).
+
+Change from:
+
+```markdown
+- Lint → Build pipeline
+- Lighthouse CI for performance audits on PRs
+- Deploy job (currently disabled - see TODO below)
+```
+
+To:
+
+```markdown
+- Lint → parallel Build, Test, E2E pipeline
+- Lighthouse CI for performance audits on PRs
+- Automated Vercel production deployment on main (gated behind all CI jobs)
+```
+
+## Verification Checklist
+
+- [ ] YAML syntax is well-formed (correct indentation in ci.yml)
+- [ ] JSON syntax is valid (vercel.json)
+- [ ] Job dependency graph matches the target parallel structure:
+  - `lint`: no dependencies
+  - `test`: needs lint
+  - `e2e`: needs lint
+  - `build`: needs lint
+  - `lighthouse`: needs build, PR-only
+  - `deploy`: needs [lint, test, e2e, build], main push only
+- [ ] CLAUDE.md TODO section is fully removed
+- [ ] CLAUDE.md CI/CD description accurately reflects the new pipeline

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **CI Optimization**: Fix job dependencies so `build`, `test`, and `e2e` all run in parallel after `lint`, reducing pipeline wall time from ~10min to ~6min
- **CD Implementation**: Enable Vercel production deployment on main pushes, gated behind all CI jobs (lint, test, e2e, build)
- **Auto-deploy guard**: Add `vercel.json` to disable Vercel's automatic deployment on main, ensuring deploys only happen through CI gates

### Pipeline dependency graph

```
lint ─┬─→ build ──→ lighthouse (PR only)
      ├─→ test
      └─→ e2e
      └─→ (all four) ──→ deploy (main push only)
```

### Files changed

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Add test/e2e jobs, fix parallelism, enable deploy job |
| `vercel.json` | Disable Vercel auto-deploy on main |
| `CLAUDE.md` | Remove deployment TODO, update CI/CD description |
| `docs/CI-CD-OPTIMIZATIONS.md` | Plan document for this change |

## Test plan

- [ ] CI pipeline runs lint, then build/test/e2e in parallel on this PR
- [ ] Lighthouse audit runs on this PR after build completes
- [ ] Deploy job is skipped on this PR (only runs on main push)
- [ ] After merge, deploy job triggers Vercel production deployment
- [ ] Vercel PR preview deployments still work (not disabled by vercel.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Restructured CI: lint now gates build, test, and E2E jobs; job dependencies simplified for faster, parallel feedback.
  * Enabled automated production deployment on main, gated behind all CI tasks and configured for production.
  * Added configuration to disable automatic main branch deployments.

* **Documentation**
  * Updated CI/CD docs to reflect the new pipeline, deployment flow, and removed previous TODOs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->