### PR TITLE
Fix mobile header nav: all items visible without overflow

### DIFF
--- a/components/header.tsx
+++ b/components/header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
   return (
     <header className="relative z-[999]">
       <motion.nav
-        className="fixed top-0 left-1/2 flex w-full items-center justify-center rounded-none border border-white/40 bg-white/80 px-4 py-2 shadow-lg shadow-black/[0.03] backdrop-blur-[0.5rem] sm:top-6 sm:w-[36rem] sm:rounded-full sm:px-0 sm:py-2 dark:border-black/40 dark:bg-gray-950/75"
+        className="fixed top-0 left-1/2 flex w-full items-center justify-center rounded-none border border-white/40 bg-white/80 px-4 py-2 shadow-lg shadow-black/[0.03] backdrop-blur-[0.5rem] sm:top-6 sm:w-[36rem] sm:rounded-full sm:px-0 dark:border-black/40 dark:bg-gray-950/75"
         initial={{ y: -100, x: '-50%', opacity: 0 }}
         animate={{ y: 0, x: '-50%', opacity: 1 }}
       >

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -12,13 +12,11 @@ export default function Header() {
 
   return (
     <header className="relative z-[999]">
-      <motion.div
-        className="fixed top-0 left-1/2 h-[4.5rem] w-full rounded-none border border-white/40 bg-white/80 shadow-lg shadow-black/[0.03] backdrop-blur-[0.5rem] sm:top-6 sm:h-[3.25rem] sm:w-[36rem] sm:rounded-full dark:border-black/40 dark:bg-gray-950/75"
+      <motion.nav
+        className="fixed top-0 left-1/2 flex w-full items-center justify-center rounded-none border border-white/40 bg-white/80 px-4 py-2 shadow-lg shadow-black/[0.03] backdrop-blur-[0.5rem] sm:top-6 sm:w-[36rem] sm:rounded-full sm:px-0 sm:py-2 dark:border-black/40 dark:bg-gray-950/75"
         initial={{ y: -100, x: '-50%', opacity: 0 }}
         animate={{ y: 0, x: '-50%', opacity: 1 }}
-      ></motion.div>
-
-      <nav className="fixed top-[0.15rem] left-1/2 flex h-12 -translate-x-1/2 items-center gap-2 py-2 sm:top-[1.7rem] sm:h-[initial] sm:py-0">
+      >
         <ul className="flex w-full flex-wrap items-center justify-center gap-y-1 text-[0.75rem] font-medium text-gray-500 sm:w-[initial] sm:flex-nowrap sm:gap-5 sm:text-[0.9rem]">
           {links.map((link) => (
             <motion.li
@@ -58,7 +56,7 @@ export default function Header() {
             </motion.li>
           ))}
         </ul>
-      </nav>
+      </motion.nav>
     </header>
   );
 }


### PR DESCRIPTION
Merge the separate background div and nav into a single motion.nav element so the frosted glass container naturally wraps around all nav items. On mobile, items wrap to multiple lines and the header grows to fit. Previously, the fixed-height background and nav caused only 4 of 6 items to be visible with the last row overflowing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the header component with improved semantic markup and a simplified layout architecture for better code organization.
  * Enhanced responsive design behavior with refined styling adjustments, flexbox-based layout improvements, and breakpoint optimizations for consistent visual presentation across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->