### PR TITLE
Add admin dashboard (Phase 4B-4H): editors, tests, polish

### DIFF
--- a/__tests__/actions/admin.test.ts
+++ b/__tests__/actions/admin.test.ts
@@ -1,0 +1,676 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  createMockSupabaseClient,
+  createChainMock,
+  MOCK_ADMIN_USER,
+  MOCK_NON_ADMIN_USER,
+} from '../helpers/supabase-mock';
+import type { MockSupabaseClient } from '../helpers/supabase-mock';
+
+// Mock external dependencies before imports
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+import { revalidatePath } from 'next/cache';
+import { createClient } from '@/lib/supabase/server';
+import {
+  requireAdmin,
+  getAdminStats,
+  updateProfile,
+  updateProfileStats,
+  createExperience,
+  updateExperience,
+  deleteExperience,
+  reorderExperiences,
+  createProject,
+  updateProject,
+  deleteProject,
+  reorderProjects,
+  createSkillGroup,
+  updateSkillGroup,
+  deleteSkillGroup,
+  reorderSkillGroups,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+  reorderSkills,
+  getResumeDownloads,
+  uploadResume,
+} from '@/actions/admin';
+
+let mockClient: MockSupabaseClient;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockClient = createMockSupabaseClient();
+  vi.mocked(createClient).mockResolvedValue(mockClient as never);
+});
+
+/** Helper: configure mock as an authenticated admin */
+function setAdmin() {
+  mockClient._setAuth(MOCK_ADMIN_USER);
+}
+
+// ─── requireAdmin ────────────────────────────────────────────
+
+describe('requireAdmin', () => {
+  it('returns error when not authenticated', async () => {
+    mockClient._setAuth(null, { message: 'No session' });
+    const result = await requireAdmin();
+    expect(result.error).toBe('Not authenticated');
+  });
+
+  it('returns error when user is not admin', async () => {
+    mockClient._setAuth(MOCK_NON_ADMIN_USER);
+    const result = await requireAdmin();
+    expect(result.error).toBe('Not authorized — admin role required');
+  });
+
+  it('returns user when user is admin', async () => {
+    setAdmin();
+    const result = await requireAdmin();
+    expect(result.user).toEqual(MOCK_ADMIN_USER);
+    expect(result.error).toBeUndefined();
+  });
+});
+
+// ─── getAdminStats ───────────────────────────────────────────
+
+describe('getAdminStats', () => {
+  it('returns error when not admin', async () => {
+    mockClient._setAuth(null);
+    const result = await getAdminStats();
+    expect(result.error).toBe('Not authenticated');
+  });
+
+  it('returns aggregated stats on success', async () => {
+    setAdmin();
+
+    const rawDownloads = [{ id: 'dl-1', downloaded_at: '2025-01-01T00:00:00Z', visitor_id: 'v-1' }];
+    const visitors = [{ id: 'v-1', full_name: 'Jane', email: 'jane@test.com', company: 'Corp' }];
+
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 100 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 50 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 10 }))
+      .mockReturnValueOnce(createChainMock({ data: rawDownloads, error: null }))
+      .mockReturnValueOnce(createChainMock({ data: visitors, error: null }));
+
+    const result = await getAdminStats();
+    expect(result.data).toEqual({
+      totalVisitors: 100,
+      totalDownloads: 50,
+      recentDownloads: 10,
+      recentDownloadsList: [
+        {
+          id: 'dl-1',
+          downloadedAt: '2025-01-01T00:00:00Z',
+          visitorName: 'Jane',
+          visitorEmail: 'jane@test.com',
+          visitorCompany: 'Corp',
+        },
+      ],
+    });
+  });
+
+  it('returns error when visitor_profiles query fails', async () => {
+    setAdmin();
+    mockClient.from
+      .mockReturnValueOnce(
+        createChainMock({ data: null, error: { message: 'DB error' }, count: null })
+      )
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 0 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 0 }))
+      .mockReturnValueOnce(createChainMock({ data: [], error: null }));
+
+    const result = await getAdminStats();
+    expect(result.error).toBe('Failed to load visitor stats');
+  });
+
+  it('returns error when total downloads query fails', async () => {
+    setAdmin();
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 100 }))
+      .mockReturnValueOnce(
+        createChainMock({ data: null, error: { message: 'DB error' }, count: null })
+      )
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 0 }))
+      .mockReturnValueOnce(createChainMock({ data: [], error: null }));
+
+    const result = await getAdminStats();
+    expect(result.error).toBe('Failed to load download stats');
+  });
+
+  it('returns error when recent downloads query fails', async () => {
+    setAdmin();
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 100 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 50 }))
+      .mockReturnValueOnce(
+        createChainMock({ data: null, error: { message: 'DB error' }, count: null })
+      )
+      .mockReturnValueOnce(createChainMock({ data: [], error: null }));
+
+    const result = await getAdminStats();
+    expect(result.error).toBe('Failed to load recent download stats');
+  });
+
+  it('returns error when downloads list query fails', async () => {
+    setAdmin();
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 100 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 50 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 10 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: { message: 'DB error' } }));
+
+    const result = await getAdminStats();
+    expect(result.error).toBe('Failed to load downloads list');
+  });
+
+  it('returns empty downloads list when no downloads exist', async () => {
+    setAdmin();
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 100 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 0 }))
+      .mockReturnValueOnce(createChainMock({ data: null, error: null, count: 0 }))
+      .mockReturnValueOnce(createChainMock({ data: [], error: null }));
+
+    const result = await getAdminStats();
+    expect(result.data!.recentDownloadsList).toEqual([]);
+  });
+});
+
+// ─── updateProfile ───────────────────────────────────────────
+
+describe('updateProfile', () => {
+  it('returns error when not admin', async () => {
+    mockClient._setAuth(null);
+    const result = await updateProfile({ full_name: 'Test' });
+    expect(result.error).toBe('Not authenticated');
+  });
+
+  it('updates profile and calls revalidatePath on success', async () => {
+    setAdmin();
+    mockClient._setTableResponse('profile', { data: null, error: null });
+
+    const result = await updateProfile({ full_name: 'Updated Name' });
+    expect(result.data).toEqual({ success: true });
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(mockClient.from).toHaveBeenCalledWith('profile');
+  });
+
+  it('returns error on database failure', async () => {
+    setAdmin();
+    mockClient._setTableResponse('profile', {
+      data: null,
+      error: { message: 'DB error' },
+    });
+
+    const result = await updateProfile({ full_name: 'Test' });
+    expect(result.error).toBe('Failed to update profile');
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+});
+
+// ─── updateProfileStats ─────────────────────────────────────
+
+describe('updateProfileStats', () => {
+  it('returns error when not admin', async () => {
+    mockClient._setAuth(null);
+    const result = await updateProfileStats([]);
+    expect(result.error).toBe('Not authenticated');
+  });
+
+  it('deletes existing stats and inserts new ones on success', async () => {
+    setAdmin();
+    // Both delete and insert calls hit profile_stats — both succeed
+    mockClient._setTableResponse('profile_stats', { data: null, error: null });
+
+    const stats = [{ value: 15, suffix: '+', label: 'Years', sort_order: 0 }];
+    const result = await updateProfileStats(stats);
+    expect(result.data).toEqual({ success: true });
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+  });
+
+  it('returns error when delete step fails', async () => {
+    setAdmin();
+    mockClient._setTableResponse('profile_stats', {
+      data: null,
+      error: { message: 'DB error' },
+    });
+
+    const result = await updateProfileStats([{ value: 1, label: 'Test', sort_order: 0 }]);
+    expect(result.error).toBe('Failed to update stats');
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('skips insert when stats array is empty', async () => {
+    setAdmin();
+    mockClient._setTableResponse('profile_stats', { data: null, error: null });
+
+    const result = await updateProfileStats([]);
+    expect(result.data).toEqual({ success: true });
+    // from('profile_stats') called once for delete only
+    const profileStatsCalls = mockClient.from.mock.calls.filter((c) => c[0] === 'profile_stats');
+    expect(profileStatsCalls.length).toBe(1);
+  });
+});
+
+// ─── CRUD Test Helpers ───────────────────────────────────────
+
+/**
+ * Generates standard CRUD tests for create/update/delete/reorder actions.
+ */
+function describeCrud({
+  entityName,
+  tableName,
+  createFn,
+  updateFn,
+  deleteFn,
+  reorderFn,
+  sampleInsert,
+  sampleEntity,
+  createErrorMsg,
+  updateErrorMsg,
+  deleteErrorMsg,
+  reorderErrorMsg,
+}: {
+  entityName: string;
+  tableName: string;
+  createFn: (data: never) => Promise<{ data?: unknown; error?: string }>;
+  updateFn: (id: string, data: never) => Promise<{ data?: unknown; error?: string }>;
+  deleteFn: (id: string) => Promise<{ data?: unknown; error?: string }>;
+  reorderFn: (ids: string[]) => Promise<{ data?: unknown; error?: string }>;
+  sampleInsert: Record<string, unknown>;
+  sampleEntity: Record<string, unknown>;
+  createErrorMsg: string;
+  updateErrorMsg: string;
+  deleteErrorMsg: string;
+  reorderErrorMsg: string;
+}) {
+  describe(`create${entityName}`, () => {
+    it('returns error when not admin', async () => {
+      mockClient._setAuth(null);
+      const result = await createFn(sampleInsert as never);
+      expect(result.error).toBe('Not authenticated');
+    });
+
+    it('creates entity and calls revalidatePath', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, { data: sampleEntity, error: null });
+
+      const result = await createFn(sampleInsert as never);
+      expect(result.data).toEqual(sampleEntity);
+      expect(revalidatePath).toHaveBeenCalledWith('/');
+      expect(mockClient.from).toHaveBeenCalledWith(tableName);
+    });
+
+    it('returns error on database failure', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, {
+        data: null,
+        error: { message: 'DB error' },
+      });
+
+      const result = await createFn(sampleInsert as never);
+      expect(result.error).toBe(createErrorMsg);
+      expect(revalidatePath).not.toHaveBeenCalled();
+    });
+  });
+
+  describe(`update${entityName}`, () => {
+    it('returns error when not admin', async () => {
+      mockClient._setAuth(null);
+      const result = await updateFn('id-1', sampleInsert as never);
+      expect(result.error).toBe('Not authenticated');
+    });
+
+    it('updates entity and calls revalidatePath', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, { data: sampleEntity, error: null });
+
+      const result = await updateFn('id-1', sampleInsert as never);
+      expect(result.data).toEqual(sampleEntity);
+      expect(revalidatePath).toHaveBeenCalledWith('/');
+    });
+
+    it('returns error on database failure', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, {
+        data: null,
+        error: { message: 'DB error' },
+      });
+
+      const result = await updateFn('id-1', sampleInsert as never);
+      expect(result.error).toBe(updateErrorMsg);
+      expect(revalidatePath).not.toHaveBeenCalled();
+    });
+  });
+
+  describe(`delete${entityName}`, () => {
+    it('returns error when not admin', async () => {
+      mockClient._setAuth(null);
+      const result = await deleteFn('id-1');
+      expect(result.error).toBe('Not authenticated');
+    });
+
+    it('deletes entity and calls revalidatePath', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, { data: null, error: null });
+
+      const result = await deleteFn('id-1');
+      expect(result.data).toEqual({ success: true });
+      expect(revalidatePath).toHaveBeenCalledWith('/');
+    });
+
+    it('returns error on database failure', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, {
+        data: null,
+        error: { message: 'DB error' },
+      });
+
+      const result = await deleteFn('id-1');
+      expect(result.error).toBe(deleteErrorMsg);
+      expect(revalidatePath).not.toHaveBeenCalled();
+    });
+  });
+
+  describe(`reorder${entityName}s`, () => {
+    it('returns error when not admin', async () => {
+      mockClient._setAuth(null);
+      const result = await reorderFn(['id-2', 'id-1']);
+      expect(result.error).toBe('Not authenticated');
+    });
+
+    it('updates sort_order for each id and calls revalidatePath', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, { data: null, error: null });
+
+      const result = await reorderFn(['id-2', 'id-1']);
+      expect(result.data).toEqual({ success: true });
+      expect(revalidatePath).toHaveBeenCalledWith('/');
+    });
+
+    it('returns error when any update fails', async () => {
+      setAdmin();
+      mockClient._setTableResponse(tableName, {
+        data: null,
+        error: { message: 'DB error' },
+      });
+
+      const result = await reorderFn(['id-2', 'id-1']);
+      expect(result.error).toBe(reorderErrorMsg);
+      expect(revalidatePath).not.toHaveBeenCalled();
+    });
+  });
+}
+
+// ─── Experience CRUD ─────────────────────────────────────────
+
+describeCrud({
+  entityName: 'Experience',
+  tableName: 'experiences',
+  createFn: createExperience,
+  updateFn: updateExperience,
+  deleteFn: deleteExperience,
+  reorderFn: reorderExperiences,
+  sampleInsert: {
+    title: 'Senior Dev',
+    company: 'Acme',
+    description: 'Led team',
+    start_date: '2020-01-01',
+    display_date: 'Jan 2020 - Present',
+  },
+  sampleEntity: {
+    id: 'exp-1',
+    title: 'Senior Dev',
+    company: 'Acme',
+    description: 'Led team',
+    icon: 'work',
+    start_date: '2020-01-01',
+    end_date: null,
+    display_date: 'Jan 2020 - Present',
+    company_logo_url: null,
+    sort_order: 0,
+  },
+  createErrorMsg: 'Failed to create experience',
+  updateErrorMsg: 'Failed to update experience',
+  deleteErrorMsg: 'Failed to delete experience',
+  reorderErrorMsg: 'Failed to reorder experiences',
+});
+
+// ─── Project CRUD ────────────────────────────────────────────
+
+describeCrud({
+  entityName: 'Project',
+  tableName: 'projects',
+  createFn: createProject,
+  updateFn: updateProject,
+  deleteFn: deleteProject,
+  reorderFn: reorderProjects,
+  sampleInsert: {
+    title: 'Project Alpha',
+    description: 'A project',
+    tags: ['React'],
+  },
+  sampleEntity: {
+    id: 'proj-1',
+    title: 'Project Alpha',
+    description: 'A project',
+    tags: ['React'],
+    image_url: null,
+    demo_video_url: null,
+    source_code_url: null,
+    live_site_url: null,
+    category_id: null,
+    sort_order: 0,
+  },
+  createErrorMsg: 'Failed to create project',
+  updateErrorMsg: 'Failed to update project',
+  deleteErrorMsg: 'Failed to delete project',
+  reorderErrorMsg: 'Failed to reorder projects',
+});
+
+// ─── SkillGroup CRUD ─────────────────────────────────────────
+
+describeCrud({
+  entityName: 'SkillGroup',
+  tableName: 'skill_groups',
+  createFn: createSkillGroup,
+  updateFn: updateSkillGroup,
+  deleteFn: deleteSkillGroup,
+  reorderFn: reorderSkillGroups,
+  sampleInsert: { category: 'Frontend' },
+  sampleEntity: { id: 'sg-1', category: 'Frontend', sort_order: 0 },
+  createErrorMsg: 'Failed to create skill group',
+  updateErrorMsg: 'Failed to update skill group',
+  deleteErrorMsg: 'Failed to delete skill group',
+  reorderErrorMsg: 'Failed to reorder skill groups',
+});
+
+// ─── Skill CRUD ──────────────────────────────────────────────
+
+describeCrud({
+  entityName: 'Skill',
+  tableName: 'skills',
+  createFn: createSkill,
+  updateFn: updateSkill,
+  deleteFn: deleteSkill,
+  reorderFn: reorderSkills,
+  sampleInsert: { name: 'React', group_id: 'sg-1' },
+  sampleEntity: { id: 'sk-1', name: 'React', group_id: 'sg-1', sort_order: 0 },
+  createErrorMsg: 'Failed to create skill',
+  updateErrorMsg: 'Failed to update skill',
+  deleteErrorMsg: 'Failed to delete skill',
+  reorderErrorMsg: 'Failed to reorder skills',
+});
+
+// ─── getResumeDownloads ──────────────────────────────────────
+
+describe('getResumeDownloads', () => {
+  it('returns error when not admin', async () => {
+    mockClient._setAuth(null);
+    const result = await getResumeDownloads();
+    expect(result.error).toBe('Not authenticated');
+  });
+
+  it('returns mapped download entries with visitor info', async () => {
+    setAdmin();
+
+    const rawDownloads = [
+      { id: 'dl-1', downloaded_at: '2025-06-01T00:00:00Z', visitor_id: 'v-1' },
+      { id: 'dl-2', downloaded_at: '2025-06-02T00:00:00Z', visitor_id: 'v-2' },
+    ];
+    const visitors = [
+      { id: 'v-1', full_name: 'Jane', email: 'jane@test.com', company: 'Corp' },
+      { id: 'v-2', full_name: 'Bob', email: 'bob@test.com', company: null },
+    ];
+
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: rawDownloads, error: null }))
+      .mockReturnValueOnce(createChainMock({ data: visitors, error: null }));
+
+    const result = await getResumeDownloads();
+    expect(result.data).toEqual([
+      {
+        id: 'dl-1',
+        downloadedAt: '2025-06-01T00:00:00Z',
+        visitorName: 'Jane',
+        visitorEmail: 'jane@test.com',
+        visitorCompany: 'Corp',
+      },
+      {
+        id: 'dl-2',
+        downloadedAt: '2025-06-02T00:00:00Z',
+        visitorName: 'Bob',
+        visitorEmail: 'bob@test.com',
+        visitorCompany: null,
+      },
+    ]);
+  });
+
+  it('returns empty array when no downloads exist', async () => {
+    setAdmin();
+    mockClient.from.mockReturnValueOnce(createChainMock({ data: [], error: null }));
+
+    const result = await getResumeDownloads();
+    expect(result.data).toEqual([]);
+  });
+
+  it('returns error on database failure', async () => {
+    setAdmin();
+    mockClient.from.mockReturnValueOnce(
+      createChainMock({ data: null, error: { message: 'DB error' } })
+    );
+
+    const result = await getResumeDownloads();
+    expect(result.error).toBe('Failed to load download log');
+  });
+
+  it('handles downloads without visitor_id gracefully', async () => {
+    setAdmin();
+
+    const rawDownloads = [{ id: 'dl-1', downloaded_at: '2025-06-01T00:00:00Z', visitor_id: null }];
+
+    mockClient.from.mockReturnValueOnce(createChainMock({ data: rawDownloads, error: null }));
+    // No visitor lookup call needed since visitorIds is empty
+
+    const result = await getResumeDownloads();
+    expect(result.data).toEqual([
+      {
+        id: 'dl-1',
+        downloadedAt: '2025-06-01T00:00:00Z',
+        visitorName: null,
+        visitorEmail: null,
+        visitorCompany: null,
+      },
+    ]);
+  });
+});
+
+// ─── uploadResume ────────────────────────────────────────────
+
+describe('uploadResume', () => {
+  function createFormDataWithFile(file: File): FormData {
+    const fd = new FormData();
+    fd.append('file', file);
+    return fd;
+  }
+
+  it('returns error when not admin', async () => {
+    mockClient._setAuth(null);
+    const fd = createFormDataWithFile(new File(['pdf'], 'resume.pdf', { type: 'application/pdf' }));
+    const result = await uploadResume(fd);
+    expect(result.error).toBe('Not authenticated');
+  });
+
+  it('returns error when no file is provided', async () => {
+    setAdmin();
+    const result = await uploadResume(new FormData());
+    expect(result.error).toBe('No file provided');
+  });
+
+  it('returns error for non-PDF files', async () => {
+    setAdmin();
+    const fd = createFormDataWithFile(new File(['text'], 'doc.txt', { type: 'text/plain' }));
+    const result = await uploadResume(fd);
+    expect(result.error).toBe('Only PDF files are allowed');
+  });
+
+  it('returns error for files over 10 MB', async () => {
+    setAdmin();
+    // Create a file slightly over 10 MB
+    const bigContent = new Uint8Array(10 * 1024 * 1024 + 1);
+    const fd = createFormDataWithFile(
+      new File([bigContent], 'big.pdf', { type: 'application/pdf' })
+    );
+    const result = await uploadResume(fd);
+    expect(result.error).toBe('File must be smaller than 10 MB');
+  });
+
+  it('uploads file and updates profile on success', async () => {
+    setAdmin();
+    mockClient._setStorageResponse('resume', { data: { path: 'resume.pdf' }, error: null });
+    mockClient._setTableResponse('profile', { data: null, error: null });
+
+    const file = new File(['pdf content'], 'resume.pdf', { type: 'application/pdf' });
+    const fd = createFormDataWithFile(file);
+    const result = await uploadResume(fd);
+
+    expect(result.data).toEqual({ path: 'resume.pdf' });
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(mockClient.storage.from).toHaveBeenCalledWith('resume');
+  });
+
+  it('returns error when storage upload fails', async () => {
+    setAdmin();
+    mockClient._setStorageResponse('resume', {
+      data: null,
+      error: { message: 'Storage error' },
+    });
+
+    const fd = createFormDataWithFile(new File(['pdf'], 'resume.pdf', { type: 'application/pdf' }));
+    const result = await uploadResume(fd);
+    expect(result.error).toBe('Failed to upload file');
+    expect(revalidatePath).not.toHaveBeenCalled();
+  });
+
+  it('returns error when profile update fails after upload', async () => {
+    setAdmin();
+    mockClient._setStorageResponse('resume', { data: { path: 'resume.pdf' }, error: null });
+    mockClient._setTableResponse('profile', {
+      data: null,
+      error: { message: 'DB error' },
+    });
+
+    const fd = createFormDataWithFile(new File(['pdf'], 'resume.pdf', { type: 'application/pdf' }));
+    const result = await uploadResume(fd);
+    expect(result.error).toBe('File uploaded but failed to update profile');
+  });
+});

--- a/__tests__/components/admin/experience-editor.test.tsx
+++ b/__tests__/components/admin/experience-editor.test.tsx
@@ -61,11 +61,11 @@ describe('ExperienceEditor', () => {
     expect(screen.getByRole('heading', { name: 'Add Experience' })).toBeInTheDocument();
 
     // Fill in the form
-    await user.type(screen.getByLabelText('Title'), 'Tech Lead');
-    await user.type(screen.getByLabelText('Company'), 'New Corp');
-    await user.type(screen.getByLabelText('Description'), 'Leading engineering');
-    await user.type(screen.getByLabelText('Display Date'), 'Jan 2023 - Present');
-    await user.type(screen.getByLabelText('Start Date'), '2023-01-01');
+    await user.type(screen.getByLabelText(/^title/i), 'Tech Lead');
+    await user.type(screen.getByLabelText(/^company \*/i), 'New Corp');
+    await user.type(screen.getByLabelText(/^description/i), 'Leading engineering');
+    await user.type(screen.getByLabelText(/^display date/i), 'Jan 2023 - Present');
+    await user.type(screen.getByLabelText(/^start date/i), '2023-01-01');
 
     await user.click(screen.getByRole('button', { name: /create/i }));
 
@@ -89,11 +89,11 @@ describe('ExperienceEditor', () => {
     expect(screen.getByText('Edit Experience')).toBeInTheDocument();
     await waitFor(
       () => {
-        expect(screen.getByLabelText('Title')).toHaveValue('Senior Dev');
+        expect(screen.getByLabelText(/^title/i)).toHaveValue('Senior Dev');
       },
       { timeout: 3000 }
     );
-    expect(screen.getByLabelText('Company')).toHaveValue('Acme Corp');
+    expect(screen.getByLabelText(/^company \*/i)).toHaveValue('Acme Corp');
   }, 10000);
 
   it('saves edited experience', async () => {
@@ -113,11 +113,11 @@ describe('ExperienceEditor', () => {
     // Wait for dialog to open and values to populate
     await waitFor(
       () => {
-        expect(screen.getByLabelText('Title')).toHaveValue('Senior Dev');
+        expect(screen.getByLabelText(/^title/i)).toHaveValue('Senior Dev');
       },
       { timeout: 3000 }
     );
-    const titleInput = screen.getByLabelText('Title');
+    const titleInput = screen.getByLabelText(/^title/i);
 
     await user.clear(titleInput);
     await user.type(titleInput, 'Lead Dev');
@@ -164,7 +164,11 @@ describe('ExperienceEditor', () => {
     render(<ExperienceEditor experiences={mockExperiences} />);
 
     await user.click(screen.getByRole('button', { name: /add experience/i }));
-    await user.type(screen.getByLabelText('Title'), 'Test');
+    await user.type(screen.getByLabelText(/^title/i), 'Test');
+    await user.type(screen.getByLabelText(/^company \*/i), 'TestCo');
+    await user.type(screen.getByLabelText(/^description/i), 'Desc');
+    await user.type(screen.getByLabelText(/^display date/i), '2023');
+    await user.type(screen.getByLabelText(/^start date/i), '2023-01-01');
     await user.click(screen.getByRole('button', { name: /create/i }));
 
     await waitFor(() => {

--- a/__tests__/components/admin/experience-editor.test.tsx
+++ b/__tests__/components/admin/experience-editor.test.tsx
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ExperienceEditor from '@/components/admin/experience-editor';
+import { mockExperiences } from '../../helpers/admin-fixtures';
+import type { Experience } from '@/lib/supabase/types';
+
+vi.mock('@/actions/admin', () => ({
+  createExperience: vi.fn(),
+  updateExperience: vi.fn(),
+  deleteExperience: vi.fn(),
+  reorderExperiences: vi.fn(),
+}));
+
+import {
+  createExperience,
+  updateExperience,
+  deleteExperience,
+  reorderExperiences,
+} from '@/actions/admin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ExperienceEditor', () => {
+  it('renders table with all experiences', () => {
+    render(<ExperienceEditor experiences={mockExperiences} />);
+    expect(screen.getByText('Senior Dev')).toBeInTheDocument();
+    expect(screen.getByText('Acme Corp')).toBeInTheDocument();
+    expect(screen.getByText('Dev')).toBeInTheDocument();
+    expect(screen.getByText('Startup Inc')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no experiences', () => {
+    render(<ExperienceEditor experiences={[]} />);
+    expect(screen.getByText(/no experiences yet/i)).toBeInTheDocument();
+  });
+
+  it('opens add dialog and creates experience', { timeout: 15000 }, async () => {
+    const newExp: Experience = {
+      id: 'exp-new',
+      title: 'Tech Lead',
+      company: 'New Corp',
+      description: 'Leading engineering',
+      icon: 'work',
+      start_date: '2023-01-01',
+      end_date: null,
+      display_date: 'Jan 2023 - Present',
+      company_logo_url: null,
+      sort_order: 2,
+    };
+    vi.mocked(createExperience).mockResolvedValue({ data: newExp });
+
+    const user = userEvent.setup();
+    render(<ExperienceEditor experiences={mockExperiences} />);
+
+    await user.click(screen.getByRole('button', { name: /add experience/i }));
+
+    // Dialog should open with "Add Experience" title
+    expect(screen.getByRole('heading', { name: 'Add Experience' })).toBeInTheDocument();
+
+    // Fill in the form
+    await user.type(screen.getByLabelText('Title'), 'Tech Lead');
+    await user.type(screen.getByLabelText('Company'), 'New Corp');
+    await user.type(screen.getByLabelText('Description'), 'Leading engineering');
+    await user.type(screen.getByLabelText('Display Date'), 'Jan 2023 - Present');
+    await user.type(screen.getByLabelText('Start Date'), '2023-01-01');
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(createExperience).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByText('Tech Lead')).toBeInTheDocument();
+  });
+
+  it('opens edit dialog with pre-filled data', async () => {
+    const user = userEvent.setup();
+    render(<ExperienceEditor experiences={mockExperiences} />);
+
+    // Click the first pencil (edit) button in the table
+    const rows = screen.getAllByRole('row');
+    // Row 0 is header, row 1 is first data row
+    const firstDataRow = rows[1];
+    const editBtn = within(firstDataRow).getAllByRole('button')[2]; // 3rd button (after up/down)
+    await user.click(editBtn);
+
+    expect(screen.getByText('Edit Experience')).toBeInTheDocument();
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText('Title')).toHaveValue('Senior Dev');
+      },
+      { timeout: 3000 }
+    );
+    expect(screen.getByLabelText('Company')).toHaveValue('Acme Corp');
+  }, 10000);
+
+  it('saves edited experience', async () => {
+    const updated: Experience = { ...mockExperiences[0], title: 'Lead Dev' };
+    vi.mocked(updateExperience).mockResolvedValue({ data: updated });
+
+    const user = userEvent.setup();
+    render(<ExperienceEditor experiences={mockExperiences} />);
+
+    // Open edit dialog for first experience
+    const rows = screen.getAllByRole('row');
+    const firstDataRow = rows[1];
+    const buttons = within(firstDataRow).getAllByRole('button');
+    // Buttons: [up, down, pencil, trash] → pencil is index 2
+    await user.click(buttons[2]);
+
+    // Wait for dialog to open and values to populate
+    await waitFor(
+      () => {
+        expect(screen.getByLabelText('Title')).toHaveValue('Senior Dev');
+      },
+      { timeout: 3000 }
+    );
+    const titleInput = screen.getByLabelText('Title');
+
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Lead Dev');
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateExperience).toHaveBeenCalledWith(
+        'exp-1',
+        expect.objectContaining({ title: 'Lead Dev' })
+      );
+    });
+  }, 10000);
+
+  it('opens delete dialog and confirms deletion', async () => {
+    vi.mocked(deleteExperience).mockResolvedValue({ data: { success: true } });
+
+    const user = userEvent.setup();
+    render(<ExperienceEditor experiences={mockExperiences} />);
+
+    // Click delete button on first experience
+    const rows = screen.getAllByRole('row');
+    const deleteBtn = within(rows[1]).getAllByRole('button')[3]; // 4th button (after up/down/edit)
+    await user.click(deleteBtn);
+
+    // Delete confirmation dialog should appear
+    expect(screen.getByRole('heading', { name: 'Delete Experience' })).toBeInTheDocument();
+    // The dialog description mentions the experience title
+    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
+
+    // Click the destructive "Delete" button inside the dialog
+    const dialog = screen.getByRole('dialog', { name: 'Delete Experience' });
+    await user.click(within(dialog).getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(deleteExperience).toHaveBeenCalledWith('exp-1');
+    });
+  });
+
+  it('displays error message when create fails', async () => {
+    vi.mocked(createExperience).mockResolvedValue({ error: 'Failed to create experience' });
+
+    const user = userEvent.setup();
+    render(<ExperienceEditor experiences={mockExperiences} />);
+
+    await user.click(screen.getByRole('button', { name: /add experience/i }));
+    await user.type(screen.getByLabelText('Title'), 'Test');
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create experience')).toBeInTheDocument();
+    });
+  });
+
+  it('handles reorder', async () => {
+    vi.mocked(reorderExperiences).mockResolvedValue({ data: { success: true } });
+
+    const user = userEvent.setup();
+    render(<ExperienceEditor experiences={mockExperiences} />);
+
+    // Click "down" button on first experience
+    const rows = screen.getAllByRole('row');
+    const downBtn = within(rows[1]).getAllByRole('button')[1]; // 2nd button (down arrow)
+    await user.click(downBtn);
+
+    await waitFor(() => {
+      expect(reorderExperiences).toHaveBeenCalledWith(['exp-2', 'exp-1']);
+    });
+  });
+
+  it('disables up button for first item and down button for last item', () => {
+    render(<ExperienceEditor experiences={mockExperiences} />);
+
+    const rows = screen.getAllByRole('row');
+    // First data row: up should be disabled
+    const firstRowUpBtn = within(rows[1]).getAllByRole('button')[0];
+    expect(firstRowUpBtn).toBeDisabled();
+
+    // Last data row: down should be disabled
+    const lastRowDownBtn = within(rows[2]).getAllByRole('button')[1];
+    expect(lastRowDownBtn).toBeDisabled();
+  });
+});

--- a/__tests__/components/admin/profile-form.test.tsx
+++ b/__tests__/components/admin/profile-form.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProfileForm from '@/components/admin/profile-form';
+import { mockProfile, mockStats } from '../../helpers/admin-fixtures';
+
+vi.mock('@/actions/admin', () => ({
+  updateProfile: vi.fn(),
+  updateProfileStats: vi.fn(),
+}));
+
+import { updateProfile, updateProfileStats } from '@/actions/admin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(updateProfile).mockResolvedValue({ data: { success: true } });
+  vi.mocked(updateProfileStats).mockResolvedValue({ data: { success: true } });
+});
+
+describe('ProfileForm', () => {
+  it('renders all three tabs', () => {
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+    expect(screen.getByRole('tab', { name: 'General' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'About' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Stats' })).toBeInTheDocument();
+  });
+
+  it('renders general tab fields with initial values', () => {
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+    expect(screen.getByLabelText('Full Name')).toHaveValue('John Doe');
+    expect(screen.getByLabelText('Job Title')).toHaveValue('Software Engineer');
+    expect(screen.getByLabelText('Email')).toHaveValue('john@example.com');
+  });
+
+  it('allows editing and saving general info', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+
+    const fullNameInput = screen.getByLabelText('Full Name');
+    await user.clear(fullNameInput);
+    await user.type(fullNameInput, 'Jane Doe');
+
+    await user.click(screen.getByRole('button', { name: /save general info/i }));
+
+    await waitFor(() => {
+      expect(updateProfile).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(updateProfile).mock.calls[0][0]).toMatchObject({
+      full_name: 'Jane Doe',
+    });
+    expect(screen.getByText('General info saved successfully!')).toBeInTheDocument();
+  });
+
+  it('displays error when general save fails', async () => {
+    vi.mocked(updateProfile).mockResolvedValue({ error: 'Failed to update profile' });
+    const user = userEvent.setup();
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+
+    await user.click(screen.getByRole('button', { name: /save general info/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to update profile')).toBeInTheDocument();
+    });
+  });
+
+  it('switches to About tab and renders about fields', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+
+    await user.click(screen.getByRole('tab', { name: 'About' }));
+
+    expect(screen.getByLabelText('Tech Stack')).toHaveValue('React, TypeScript');
+    expect(screen.getByLabelText('Current Focus')).toHaveValue('Next.js');
+  });
+
+  it('saves about info successfully', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+
+    await user.click(screen.getByRole('tab', { name: 'About' }));
+    await user.click(screen.getByRole('button', { name: /save about info/i }));
+
+    await waitFor(() => {
+      expect(updateProfile).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(updateProfile).mock.calls[0][0]).toMatchObject({
+      about_tech_stack: 'React, TypeScript',
+    });
+    expect(screen.getByText('About info saved successfully!')).toBeInTheDocument();
+  });
+
+  it('switches to Stats tab and renders stat cards', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+
+    await user.click(screen.getByRole('tab', { name: 'Stats' }));
+
+    expect(screen.getByText('2 stats')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Years Experience')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('Projects')).toBeInTheDocument();
+  });
+
+  it('adds a new stat row', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+
+    await user.click(screen.getByRole('tab', { name: 'Stats' }));
+    await user.click(screen.getByRole('button', { name: /add stat/i }));
+
+    expect(screen.getByText('3 stats')).toBeInTheDocument();
+  });
+
+  it('validates stats require labels before saving', async () => {
+    const user = userEvent.setup();
+    render(<ProfileForm profile={mockProfile} stats={mockStats} />);
+
+    await user.click(screen.getByRole('tab', { name: 'Stats' }));
+
+    // Add a stat with empty label
+    await user.click(screen.getByRole('button', { name: /add stat/i }));
+
+    // Try to save — new stat has empty label
+    await user.click(screen.getByRole('button', { name: /save stats/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('All stats must have a label')).toBeInTheDocument();
+    });
+    expect(updateProfileStats).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/components/admin/profile-form.test.tsx
+++ b/__tests__/components/admin/profile-form.test.tsx
@@ -27,16 +27,16 @@ describe('ProfileForm', () => {
 
   it('renders general tab fields with initial values', () => {
     render(<ProfileForm profile={mockProfile} stats={mockStats} />);
-    expect(screen.getByLabelText('Full Name')).toHaveValue('John Doe');
-    expect(screen.getByLabelText('Job Title')).toHaveValue('Software Engineer');
-    expect(screen.getByLabelText('Email')).toHaveValue('john@example.com');
+    expect(screen.getByLabelText(/^full name/i)).toHaveValue('John Doe');
+    expect(screen.getByLabelText(/^job title/i)).toHaveValue('Software Engineer');
+    expect(screen.getByLabelText(/^email/i)).toHaveValue('john@example.com');
   });
 
   it('allows editing and saving general info', async () => {
     const user = userEvent.setup();
     render(<ProfileForm profile={mockProfile} stats={mockStats} />);
 
-    const fullNameInput = screen.getByLabelText('Full Name');
+    const fullNameInput = screen.getByLabelText(/^full name/i);
     await user.clear(fullNameInput);
     await user.type(fullNameInput, 'Jane Doe');
 

--- a/__tests__/components/admin/projects-editor.test.tsx
+++ b/__tests__/components/admin/projects-editor.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProjectsEditor from '@/components/admin/projects-editor';
+import { mockProjects, mockCategories } from '../../helpers/admin-fixtures';
+import type { Project } from '@/lib/supabase/types';
+
+vi.mock('@/actions/admin', () => ({
+  createProject: vi.fn(),
+  updateProject: vi.fn(),
+  deleteProject: vi.fn(),
+  reorderProjects: vi.fn(),
+}));
+
+import { createProject, updateProject, deleteProject, reorderProjects } from '@/actions/admin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ProjectsEditor', () => {
+  it('renders table with all projects', () => {
+    render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
+    expect(screen.getByText('Project Alpha')).toBeInTheDocument();
+    expect(screen.getByText('Project Beta')).toBeInTheDocument();
+    expect(screen.getByText('Web')).toBeInTheDocument(); // category for Alpha
+  });
+
+  it('shows tag badges with overflow', () => {
+    render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
+    // Alpha has 4 tags, should show 3 + "+1"
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.getByText('Next.js')).toBeInTheDocument();
+    expect(screen.getByText('+1')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no projects', () => {
+    render(<ProjectsEditor projects={[]} categories={mockCategories} />);
+    expect(screen.getByText(/no projects yet/i)).toBeInTheDocument();
+  });
+
+  it('opens add dialog and creates project', { timeout: 10000 }, async () => {
+    const newProject: Project = {
+      id: 'proj-new',
+      title: 'New Project',
+      description: 'A new project',
+      tags: ['Vue', 'Vite'],
+      image_url: null,
+      demo_video_url: null,
+      source_code_url: null,
+      live_site_url: null,
+      category_id: null,
+      sort_order: 2,
+    };
+    vi.mocked(createProject).mockResolvedValue({ data: newProject });
+
+    const user = userEvent.setup();
+    render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
+
+    await user.click(screen.getByRole('button', { name: /add project/i }));
+
+    expect(screen.getByRole('heading', { name: 'Add Project' })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Title'), 'New Project');
+    await user.type(screen.getByLabelText('Description'), 'A new project');
+    await user.type(screen.getByLabelText('Tags'), 'Vue, Vite');
+
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(createProject).toHaveBeenCalledTimes(1);
+    });
+    const callArgs = vi.mocked(createProject).mock.calls[0][0];
+    expect(callArgs.tags).toEqual(['Vue', 'Vite']);
+  });
+
+  it('saves edited project', async () => {
+    const updated: Project = { ...mockProjects[0], title: 'Updated Alpha' };
+    vi.mocked(updateProject).mockResolvedValue({ data: updated });
+
+    const user = userEvent.setup();
+    render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
+
+    // Click edit on first project
+    const rows = screen.getAllByRole('row');
+    const editBtn = within(rows[1]).getAllByRole('button')[2];
+    await user.click(editBtn);
+
+    expect(screen.getByText('Edit Project')).toBeInTheDocument();
+
+    const titleInput = screen.getByLabelText('Title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Updated Alpha');
+
+    await user.click(screen.getByRole('button', { name: /save changes/i }));
+
+    await waitFor(() => {
+      expect(updateProject).toHaveBeenCalledWith(
+        'proj-1',
+        expect.objectContaining({ title: 'Updated Alpha' })
+      );
+    });
+  });
+
+  it('opens delete dialog and confirms deletion', async () => {
+    vi.mocked(deleteProject).mockResolvedValue({ data: { success: true } });
+
+    const user = userEvent.setup();
+    render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
+
+    const rows = screen.getAllByRole('row');
+    const deleteBtn = within(rows[1]).getAllByRole('button')[3];
+    await user.click(deleteBtn);
+
+    expect(screen.getByRole('heading', { name: 'Delete Project' })).toBeInTheDocument();
+    expect(screen.getByText(/are you sure you want to delete/i)).toBeInTheDocument();
+
+    const dialog = screen.getByRole('dialog', { name: 'Delete Project' });
+    await user.click(within(dialog).getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(deleteProject).toHaveBeenCalledWith('proj-1');
+    });
+  });
+
+  it('displays error on save failure', async () => {
+    vi.mocked(createProject).mockResolvedValue({ error: 'Failed to create project' });
+
+    const user = userEvent.setup();
+    render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
+
+    await user.click(screen.getByRole('button', { name: /add project/i }));
+    await user.type(screen.getByLabelText('Title'), 'Test');
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to create project')).toBeInTheDocument();
+    });
+  });
+
+  it('handles reorder', async () => {
+    vi.mocked(reorderProjects).mockResolvedValue({ data: { success: true } });
+
+    const user = userEvent.setup();
+    render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
+
+    const rows = screen.getAllByRole('row');
+    const downBtn = within(rows[1]).getAllByRole('button')[1]; // down arrow
+    await user.click(downBtn);
+
+    await waitFor(() => {
+      expect(reorderProjects).toHaveBeenCalledWith(['proj-2', 'proj-1']);
+    });
+  });
+});

--- a/__tests__/components/admin/projects-editor.test.tsx
+++ b/__tests__/components/admin/projects-editor.test.tsx
@@ -62,8 +62,8 @@ describe('ProjectsEditor', () => {
 
     expect(screen.getByRole('heading', { name: 'Add Project' })).toBeInTheDocument();
 
-    await user.type(screen.getByLabelText('Title'), 'New Project');
-    await user.type(screen.getByLabelText('Description'), 'A new project');
+    await user.type(screen.getByLabelText(/^title/i), 'New Project');
+    await user.type(screen.getByLabelText(/^description/i), 'A new project');
     await user.type(screen.getByLabelText('Tags'), 'Vue, Vite');
 
     await user.click(screen.getByRole('button', { name: /create/i }));
@@ -89,7 +89,7 @@ describe('ProjectsEditor', () => {
 
     expect(screen.getByText('Edit Project')).toBeInTheDocument();
 
-    const titleInput = screen.getByLabelText('Title');
+    const titleInput = screen.getByLabelText(/^title/i);
     await user.clear(titleInput);
     await user.type(titleInput, 'Updated Alpha');
 
@@ -131,7 +131,8 @@ describe('ProjectsEditor', () => {
     render(<ProjectsEditor projects={mockProjects} categories={mockCategories} />);
 
     await user.click(screen.getByRole('button', { name: /add project/i }));
-    await user.type(screen.getByLabelText('Title'), 'Test');
+    await user.type(screen.getByLabelText(/^title/i), 'Test');
+    await user.type(screen.getByLabelText(/^description/i), 'Test desc');
     await user.click(screen.getByRole('button', { name: /create/i }));
 
     await waitFor(() => {

--- a/__tests__/components/admin/resume-manager.test.tsx
+++ b/__tests__/components/admin/resume-manager.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ResumeManager from '@/components/admin/resume-manager';
+import { mockDownloads } from '../../helpers/admin-fixtures';
+
+vi.mock('@/actions/admin', () => ({
+  uploadResume: vi.fn(),
+}));
+
+import { uploadResume } from '@/actions/admin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ResumeManager', () => {
+  it('renders heading and upload button', () => {
+    render(<ResumeManager resumeUrl={null} updatedAt="2025-01-01T00:00:00Z" downloads={[]} />);
+    expect(screen.getByRole('heading', { name: 'Resume Management' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /upload resume/i })).toBeInTheDocument();
+  });
+
+  it('displays current resume path when resume exists', () => {
+    render(
+      <ResumeManager resumeUrl="resume.pdf" updatedAt="2025-01-01T00:00:00Z" downloads={[]} />
+    );
+    expect(screen.getByText('resume.pdf')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /replace resume/i })).toBeInTheDocument();
+  });
+
+  it('shows "No resume uploaded" when resumeUrl is null', () => {
+    render(<ResumeManager resumeUrl={null} updatedAt="2025-01-01T00:00:00Z" downloads={[]} />);
+    expect(screen.getByText('No resume uploaded')).toBeInTheDocument();
+  });
+
+  it('displays download log table with visitor info', () => {
+    render(
+      <ResumeManager
+        resumeUrl="resume.pdf"
+        updatedAt="2025-01-01T00:00:00Z"
+        downloads={mockDownloads}
+      />
+    );
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    expect(screen.getByText('TechCo')).toBeInTheDocument();
+    // Null visitor renders em dashes
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows empty state when no downloads', () => {
+    render(
+      <ResumeManager resumeUrl="resume.pdf" updatedAt="2025-01-01T00:00:00Z" downloads={[]} />
+    );
+    expect(screen.getByText('No downloads recorded yet.')).toBeInTheDocument();
+  });
+
+  it('calls uploadResume on file selection and shows success', async () => {
+    vi.mocked(uploadResume).mockResolvedValue({ data: { path: 'resume.pdf' } });
+
+    const { container } = render(
+      <ResumeManager resumeUrl={null} updatedAt="2025-01-01T00:00:00Z" downloads={[]} />
+    );
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['pdf content'], 'resume.pdf', { type: 'application/pdf' });
+
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(screen.getByText('Resume uploaded successfully!')).toBeInTheDocument();
+    });
+    expect(uploadResume).toHaveBeenCalledTimes(1);
+  });
+
+  it('displays error message when upload fails', async () => {
+    vi.mocked(uploadResume).mockResolvedValue({ error: 'Failed to upload file' });
+
+    const { container } = render(
+      <ResumeManager resumeUrl={null} updatedAt="2025-01-01T00:00:00Z" downloads={[]} />
+    );
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['pdf'], 'resume.pdf', { type: 'application/pdf' });
+
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to upload file')).toBeInTheDocument();
+    });
+  });
+
+  it('shows uploading state while upload is in progress', async () => {
+    // Create a promise that we control
+    let resolveUpload: (value: { data: { path: string } }) => void;
+    vi.mocked(uploadResume).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveUpload = resolve;
+        })
+    );
+
+    const { container } = render(
+      <ResumeManager resumeUrl="resume.pdf" updatedAt="2025-01-01T00:00:00Z" downloads={[]} />
+    );
+
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['pdf'], 'resume.pdf', { type: 'application/pdf' });
+
+    await userEvent.upload(fileInput, file);
+
+    // While uploading, button should show "Uploading..."
+    expect(screen.getByRole('button', { name: /uploading/i })).toBeDisabled();
+
+    // Resolve the upload
+    resolveUpload!({ data: { path: 'resume.pdf' } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /replace resume/i })).not.toBeDisabled();
+    });
+  });
+});

--- a/__tests__/components/admin/skills-editor.test.tsx
+++ b/__tests__/components/admin/skills-editor.test.tsx
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SkillsEditor from '@/components/admin/skills-editor';
+import { mockSkillGroups } from '../../helpers/admin-fixtures';
+import type { SkillGroup, Skill } from '@/lib/supabase/types';
+
+vi.mock('@/actions/admin', () => ({
+  createSkillGroup: vi.fn(),
+  updateSkillGroup: vi.fn(),
+  deleteSkillGroup: vi.fn(),
+  reorderSkillGroups: vi.fn(),
+  createSkill: vi.fn(),
+  updateSkill: vi.fn(),
+  deleteSkill: vi.fn(),
+  reorderSkills: vi.fn(),
+}));
+
+import {
+  createSkillGroup,
+  updateSkillGroup,
+  deleteSkillGroup,
+  reorderSkillGroups,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+} from '@/actions/admin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('SkillsEditor', () => {
+  // --- Group operations ---
+
+  it('renders all skill groups with their skills', () => {
+    render(<SkillsEditor groups={mockSkillGroups} />);
+    expect(screen.getByText('Frontend')).toBeInTheDocument();
+    expect(screen.getByText('Backend')).toBeInTheDocument();
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+    expect(screen.getByText('Node.js')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no groups', () => {
+    render(<SkillsEditor groups={[]} />);
+    expect(screen.getByText(/no skill groups yet/i)).toBeInTheDocument();
+  });
+
+  it('opens add group dialog and creates group', async () => {
+    const newGroup: SkillGroup = { id: 'sg-new', category: 'DevOps', sort_order: 2 };
+    vi.mocked(createSkillGroup).mockResolvedValue({ data: newGroup });
+
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    await user.click(screen.getByRole('button', { name: /add group/i }));
+
+    expect(screen.getByText('Add Skill Group')).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText('Group Name'), 'DevOps');
+    await user.click(screen.getByRole('button', { name: /create/i }));
+
+    await waitFor(() => {
+      expect(createSkillGroup).toHaveBeenCalledWith({
+        category: 'DevOps',
+        sort_order: 2,
+      });
+    });
+  });
+
+  it('opens edit group dialog and renames group', async () => {
+    const updatedGroup: SkillGroup = { id: 'sg-1', category: 'Frontend & UI', sort_order: 0 };
+    vi.mocked(updateSkillGroup).mockResolvedValue({ data: updatedGroup });
+
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    // Find the edit button for the Frontend group card
+    // Each card has: [up, down] reorder buttons in CardHeader, then [pencil, trash] in CardAction
+    // We need the pencil button associated with "Frontend"
+    const allPencilButtons = screen.getAllByRole('button').filter((btn) => {
+      // Pencil buttons that are in CardAction sections (size-7)
+      return btn.className.includes('size-7') && btn.querySelector('svg');
+    });
+    // First pencil (size-7) button should be for Frontend group
+    await user.click(allPencilButtons[0]);
+
+    expect(screen.getByText('Edit Skill Group')).toBeInTheDocument();
+    expect(screen.getByLabelText('Group Name')).toHaveValue('Frontend');
+
+    const nameInput = screen.getByLabelText('Group Name');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'Frontend & UI');
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    await waitFor(() => {
+      expect(updateSkillGroup).toHaveBeenCalledWith('sg-1', { category: 'Frontend & UI' });
+    });
+  });
+
+  it('opens delete group dialog showing skill count warning', async () => {
+    vi.mocked(deleteSkillGroup).mockResolvedValue({ data: { success: true } });
+
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    // Click trash button on Frontend group (has 2 skills)
+    const allTrashButtons = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.className.includes('size-7') && btn.querySelector('svg'));
+    // Second size-7 button per group should be trash — allTrashButtons[1] for Frontend group
+    await user.click(allTrashButtons[1]);
+
+    expect(screen.getByText('Delete Skill Group')).toBeInTheDocument();
+    expect(screen.getByText(/2 skills/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(deleteSkillGroup).toHaveBeenCalledWith('sg-1');
+    });
+  });
+
+  // --- Skill operations ---
+
+  it('adds a skill inline via input + button', async () => {
+    const newSkill: Skill = { id: 'sk-new', name: 'Vue', group_id: 'sg-1', sort_order: 2 };
+    vi.mocked(createSkill).mockResolvedValue({ data: newSkill });
+
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    // Find the first "New skill name..." input
+    const inputs = screen.getAllByPlaceholderText('New skill name...');
+    await user.type(inputs[0], 'Vue');
+
+    // Click the plus button (small, outline, next to input)
+    const addSkillBtns = screen
+      .getAllByRole('button')
+      .filter((btn) => btn.closest('.flex.items-center.gap-2.pt-2') !== null);
+    await user.click(addSkillBtns[0]);
+
+    await waitFor(() => {
+      expect(createSkill).toHaveBeenCalledWith({
+        name: 'Vue',
+        group_id: 'sg-1',
+        sort_order: 2,
+      });
+    });
+  });
+
+  it('adds a skill via Enter key', async () => {
+    const newSkill: Skill = { id: 'sk-new', name: 'Vue', group_id: 'sg-1', sort_order: 2 };
+    vi.mocked(createSkill).mockResolvedValue({ data: newSkill });
+
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    const inputs = screen.getAllByPlaceholderText('New skill name...');
+    await user.type(inputs[0], 'Vue');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(createSkill).toHaveBeenCalledWith({
+        name: 'Vue',
+        group_id: 'sg-1',
+        sort_order: 2,
+      });
+    });
+  });
+
+  it('starts inline edit on skill and saves with Enter', async () => {
+    const updatedSkill: Skill = { id: 'sk-1', name: 'React.js', group_id: 'sg-1', sort_order: 0 };
+    vi.mocked(updateSkill).mockResolvedValue({ data: updatedSkill });
+
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    // Find the pencil button for "React" skill
+    // Skills have smaller pencil buttons (size-6)
+    const reactText = screen.getByText('React');
+    const skillRow = reactText.closest('.flex.items-center');
+    const editBtns = skillRow!.querySelectorAll('button');
+    // In non-editing mode: [up, down, pencil, trash]
+    const pencilBtn = editBtns[2]; // pencil
+    await user.click(pencilBtn);
+
+    // Input should appear with "React" value
+    const editInput = screen.getByDisplayValue('React');
+    await user.clear(editInput);
+    await user.type(editInput, 'React.js');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(updateSkill).toHaveBeenCalledWith('sk-1', { name: 'React.js' });
+    });
+  });
+
+  it('cancels inline edit with Escape', async () => {
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    // Start editing React skill
+    const reactText = screen.getByText('React');
+    const skillRow = reactText.closest('.flex.items-center');
+    const editBtns = skillRow!.querySelectorAll('button');
+    await user.click(editBtns[2]); // pencil
+
+    // Input should appear
+    const editInput = screen.getByDisplayValue('React');
+    await user.keyboard('{Escape}');
+
+    // Should exit edit mode — "React" text should be visible again (not in input)
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(updateSkill).not.toHaveBeenCalled();
+  });
+
+  it('deletes a skill', async () => {
+    vi.mocked(deleteSkill).mockResolvedValue({ data: { success: true } });
+
+    const user = userEvent.setup();
+    render(<SkillsEditor groups={mockSkillGroups} />);
+
+    // Find the trash button for "TypeScript" skill
+    const tsText = screen.getByText('TypeScript');
+    const skillRow = tsText.closest('.flex.items-center');
+    const btns = skillRow!.querySelectorAll('button');
+    const trashBtn = btns[3]; // [up, down, pencil, trash]
+    await user.click(trashBtn);
+
+    await waitFor(() => {
+      expect(deleteSkill).toHaveBeenCalledWith('sk-2');
+    });
+  });
+});

--- a/__tests__/components/admin/skills-editor.test.tsx
+++ b/__tests__/components/admin/skills-editor.test.tsx
@@ -47,7 +47,7 @@ describe('SkillsEditor', () => {
     expect(screen.getByText(/no skill groups yet/i)).toBeInTheDocument();
   });
 
-  it('opens add group dialog and creates group', async () => {
+  it('opens add group dialog and creates group', { timeout: 10000 }, async () => {
     const newGroup: SkillGroup = { id: 'sg-new', category: 'DevOps', sort_order: 2 };
     vi.mocked(createSkillGroup).mockResolvedValue({ data: newGroup });
 

--- a/__tests__/helpers/admin-fixtures.ts
+++ b/__tests__/helpers/admin-fixtures.ts
@@ -1,0 +1,130 @@
+import type {
+  Profile,
+  ProfileStat,
+  Experience,
+  Project,
+  ProjectCategory,
+  SkillGroupWithSkills,
+} from '@/lib/supabase/types';
+import type { ResumeDownloadEntry } from '@/actions/admin';
+
+export const mockProfile: Profile = {
+  id: 'profile-1',
+  singleton: true,
+  full_name: 'John Doe',
+  short_name: 'John',
+  job_title: 'Software Engineer',
+  tagline: 'Building great software',
+  typewriter_titles: ['Developer', 'Architect'],
+  email: 'john@example.com',
+  phone: '+1234567890',
+  location: 'New York',
+  linkedin_url: 'https://linkedin.com/in/johndoe',
+  github_url: 'https://github.com/johndoe',
+  resume_url: 'resume.pdf',
+  about_tech_stack: 'React, TypeScript',
+  about_current_focus: 'Next.js',
+  about_beyond_code: 'Music',
+  about_expertise: ['Frontend', 'Backend'],
+  footer_text: 'Built with love',
+  updated_at: '2025-01-01T00:00:00Z',
+};
+
+export const mockStats: ProfileStat[] = [
+  { id: 'stat-1', value: 15, suffix: '+', label: 'Years Experience', sort_order: 0 },
+  { id: 'stat-2', value: 50, suffix: '+', label: 'Projects', sort_order: 1 },
+];
+
+export const mockExperiences: Experience[] = [
+  {
+    id: 'exp-1',
+    title: 'Senior Dev',
+    company: 'Acme Corp',
+    description: 'Led team',
+    icon: 'work',
+    start_date: '2020-01-01',
+    end_date: null,
+    display_date: 'Jan 2020 - Present',
+    company_logo_url: null,
+    sort_order: 0,
+  },
+  {
+    id: 'exp-2',
+    title: 'Dev',
+    company: 'Startup Inc',
+    description: 'Built features',
+    icon: 'react',
+    start_date: '2018-01-01',
+    end_date: '2019-12-31',
+    display_date: 'Jan 2018 - Dec 2019',
+    company_logo_url: '/companies/startup.webp',
+    sort_order: 1,
+  },
+];
+
+export const mockCategories: ProjectCategory[] = [
+  { id: 'cat-1', name: 'Web', sort_order: 0 },
+  { id: 'cat-2', name: 'Mobile', sort_order: 1 },
+];
+
+export const mockProjects: Project[] = [
+  {
+    id: 'proj-1',
+    title: 'Project Alpha',
+    description: 'A great project',
+    tags: ['React', 'TypeScript', 'Next.js', 'Tailwind'],
+    image_url: '/images/alpha.png',
+    demo_video_url: null,
+    source_code_url: 'https://github.com/alpha',
+    live_site_url: 'https://alpha.dev',
+    category_id: 'cat-1',
+    sort_order: 0,
+  },
+  {
+    id: 'proj-2',
+    title: 'Project Beta',
+    description: 'Another project',
+    tags: ['Python', 'Django'],
+    image_url: null,
+    demo_video_url: null,
+    source_code_url: null,
+    live_site_url: null,
+    category_id: null,
+    sort_order: 1,
+  },
+];
+
+export const mockSkillGroups: SkillGroupWithSkills[] = [
+  {
+    id: 'sg-1',
+    category: 'Frontend',
+    sort_order: 0,
+    skills: [
+      { id: 'sk-1', name: 'React', group_id: 'sg-1', sort_order: 0 },
+      { id: 'sk-2', name: 'TypeScript', group_id: 'sg-1', sort_order: 1 },
+    ],
+  },
+  {
+    id: 'sg-2',
+    category: 'Backend',
+    sort_order: 1,
+    skills: [{ id: 'sk-3', name: 'Node.js', group_id: 'sg-2', sort_order: 0 }],
+  },
+];
+
+export const mockDownloads: ResumeDownloadEntry[] = [
+  {
+    id: 'dl-1',
+    downloadedAt: new Date(Date.now() - 3600000).toISOString(),
+    visitorName: 'Jane Smith',
+    visitorEmail: 'jane@example.com',
+    visitorCompany: 'TechCo',
+  },
+  {
+    id: 'dl-2',
+    downloadedAt: new Date(Date.now() - 86400000).toISOString(),
+    visitorName: null,
+    visitorEmail: null,
+    visitorCompany: null,
+  },
+];

--- a/__tests__/helpers/supabase-mock.ts
+++ b/__tests__/helpers/supabase-mock.ts
@@ -1,0 +1,123 @@
+import { vi } from 'vitest';
+
+type SupabaseResponse = { data: unknown; error: unknown; count?: number | null };
+
+/**
+ * Creates a chainable mock that mimics the Supabase query builder.
+ * Every intermediate method returns `this`. When awaited, resolves to { data, error, count }.
+ */
+export function createChainMock(
+  response: SupabaseResponse = { data: null, error: null }
+): Record<string, ReturnType<typeof vi.fn>> & PromiseLike<SupabaseResponse> {
+  const chain = {} as Record<string, ReturnType<typeof vi.fn>> & PromiseLike<SupabaseResponse>;
+
+  const methods = [
+    'select',
+    'insert',
+    'update',
+    'delete',
+    'upsert',
+    'eq',
+    'neq',
+    'gt',
+    'gte',
+    'lt',
+    'lte',
+    'in',
+    'order',
+    'limit',
+    'single',
+    'maybeSingle',
+    'filter',
+    'match',
+    'range',
+  ];
+
+  for (const method of methods) {
+    chain[method] = vi.fn().mockReturnValue(chain);
+  }
+
+  // Thenable so `await` resolves to the configured response
+  chain.then = vi.fn((resolve: (value: SupabaseResponse) => void) =>
+    resolve(response)
+  ) as unknown as PromiseLike<SupabaseResponse>['then'];
+
+  return chain;
+}
+
+export function createStorageBucketMock(
+  response: { data: unknown; error: unknown } = { data: null, error: null }
+) {
+  return {
+    upload: vi.fn().mockResolvedValue(response),
+    download: vi.fn().mockResolvedValue(response),
+    remove: vi.fn().mockResolvedValue(response),
+    createSignedUrl: vi.fn().mockResolvedValue(response),
+    getPublicUrl: vi.fn().mockReturnValue({
+      data: { publicUrl: 'https://example.com/file.pdf' },
+    }),
+  };
+}
+
+export type MockSupabaseClient = ReturnType<typeof createMockSupabaseClient>;
+
+export function createMockSupabaseClient() {
+  const tableResponses = new Map<string, SupabaseResponse>();
+  const storageResponses = new Map<string, { data: unknown; error: unknown }>();
+
+  const client = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: null },
+        error: null,
+      }),
+    },
+
+    from: vi.fn((table: string) => {
+      const response = tableResponses.get(table) ?? { data: null, error: null };
+      return createChainMock(response);
+    }),
+
+    storage: {
+      from: vi.fn((bucket: string) => {
+        const response = storageResponses.get(bucket) ?? {
+          data: null,
+          error: null,
+        };
+        return createStorageBucketMock(response);
+      }),
+    },
+
+    // --- Test helpers ---
+
+    _setTableResponse(table: string, response: SupabaseResponse) {
+      tableResponses.set(table, response);
+    },
+
+    _setStorageResponse(bucket: string, response: { data: unknown; error: unknown }) {
+      storageResponses.set(bucket, response);
+    },
+
+    _setAuth(user: unknown, error: unknown = null) {
+      client.auth.getUser.mockResolvedValue({ data: { user }, error });
+    },
+  };
+
+  return client;
+}
+
+// --- Auth fixtures ---
+
+export const MOCK_ADMIN_USER = {
+  id: 'admin-user-id',
+  email: 'admin@example.com',
+  app_metadata: { role: 'admin' },
+  user_metadata: {},
+};
+
+export const MOCK_NON_ADMIN_USER = {
+  id: 'regular-user-id',
+  email: 'user@example.com',
+  app_metadata: {},
+  user_metadata: {},
+};

--- a/__tests__/helpers/supabase-mock.ts
+++ b/__tests__/helpers/supabase-mock.ts
@@ -8,9 +8,7 @@ type SupabaseResponse = { data: unknown; error: unknown; count?: number | null }
  */
 export function createChainMock(
   response: SupabaseResponse = { data: null, error: null }
-): Record<string, ReturnType<typeof vi.fn>> & PromiseLike<SupabaseResponse> {
-  const chain = {} as Record<string, ReturnType<typeof vi.fn>> & PromiseLike<SupabaseResponse>;
-
+): Record<string, ReturnType<typeof vi.fn>> & Promise<SupabaseResponse> {
   const methods = [
     'select',
     'insert',
@@ -33,14 +31,14 @@ export function createChainMock(
     'range',
   ];
 
+  const chain = Object.assign(
+    Promise.resolve(response),
+    {} as Record<string, ReturnType<typeof vi.fn>>
+  );
+
   for (const method of methods) {
     chain[method] = vi.fn().mockReturnValue(chain);
   }
-
-  // Thenable so `await` resolves to the configured response
-  chain.then = vi.fn((resolve: (value: SupabaseResponse) => void) =>
-    resolve(response)
-  ) as unknown as PromiseLike<SupabaseResponse>['then'];
 
   return chain;
 }

--- a/actions/admin.ts
+++ b/actions/admin.ts
@@ -8,6 +8,12 @@ import type {
   ProfileStatInsert,
   Experience,
   ExperienceInsert,
+  Project,
+  ProjectInsert,
+  SkillGroup,
+  SkillGroupInsert,
+  Skill,
+  SkillInsert,
 } from '@/lib/supabase/types';
 
 type AdminResult = { user: User; error?: undefined } | { user?: undefined; error: string };
@@ -288,5 +294,280 @@ export async function reorderExperiences(
 
   revalidatePath('/');
 
+  return { data: { success: true } };
+}
+
+export async function createProject(
+  data: ProjectInsert
+): Promise<{ data?: Project; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const { data: created, error: insertError } = await supabase
+    .from('projects')
+    .insert(data)
+    .select()
+    .single();
+
+  if (insertError) {
+    console.error('createProject error:', insertError.message);
+    return { error: 'Failed to create project' };
+  }
+
+  revalidatePath('/');
+
+  return { data: created };
+}
+
+export async function updateProject(
+  id: string,
+  data: Partial<ProjectInsert>
+): Promise<{ data?: Project; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const { data: updated, error: updateError } = await supabase
+    .from('projects')
+    .update(data)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (updateError) {
+    console.error('updateProject error:', updateError.message);
+    return { error: 'Failed to update project' };
+  }
+
+  revalidatePath('/');
+
+  return { data: updated };
+}
+
+export async function deleteProject(
+  id: string
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const { error: deleteError } = await supabase.from('projects').delete().eq('id', id);
+
+  if (deleteError) {
+    console.error('deleteProject error:', deleteError.message);
+    return { error: 'Failed to delete project' };
+  }
+
+  revalidatePath('/');
+
+  return { data: { success: true } };
+}
+
+export async function reorderProjects(
+  orderedIds: string[]
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const updates = orderedIds.map((id, index) =>
+    supabase.from('projects').update({ sort_order: index }).eq('id', id)
+  );
+
+  const results = await Promise.all(updates);
+  const failed = results.find((r) => r.error);
+
+  if (failed?.error) {
+    console.error('reorderProjects error:', failed.error.message);
+    return { error: 'Failed to reorder projects' };
+  }
+
+  revalidatePath('/');
+
+  return { data: { success: true } };
+}
+
+// --- Skill Group Actions ---
+
+export async function createSkillGroup(
+  data: SkillGroupInsert
+): Promise<{ data?: SkillGroup; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const { data: created, error } = await supabase
+    .from('skill_groups')
+    .insert(data)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('createSkillGroup error:', error.message);
+    return { error: 'Failed to create skill group' };
+  }
+
+  revalidatePath('/');
+  return { data: created };
+}
+
+export async function updateSkillGroup(
+  id: string,
+  data: Partial<SkillGroupInsert>
+): Promise<{ data?: SkillGroup; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const { data: updated, error } = await supabase
+    .from('skill_groups')
+    .update(data)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('updateSkillGroup error:', error.message);
+    return { error: 'Failed to update skill group' };
+  }
+
+  revalidatePath('/');
+  return { data: updated };
+}
+
+export async function deleteSkillGroup(
+  id: string
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const { error } = await supabase.from('skill_groups').delete().eq('id', id);
+
+  if (error) {
+    console.error('deleteSkillGroup error:', error.message);
+    return { error: 'Failed to delete skill group' };
+  }
+
+  revalidatePath('/');
+  return { data: { success: true } };
+}
+
+export async function reorderSkillGroups(
+  orderedIds: string[]
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const updates = orderedIds.map((id, index) =>
+    supabase.from('skill_groups').update({ sort_order: index }).eq('id', id)
+  );
+
+  const results = await Promise.all(updates);
+  const failed = results.find((r) => r.error);
+
+  if (failed?.error) {
+    console.error('reorderSkillGroups error:', failed.error.message);
+    return { error: 'Failed to reorder skill groups' };
+  }
+
+  revalidatePath('/');
+  return { data: { success: true } };
+}
+
+// --- Skill Actions ---
+
+export async function createSkill(data: SkillInsert): Promise<{ data?: Skill; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const { data: created, error } = await supabase.from('skills').insert(data).select().single();
+
+  if (error) {
+    console.error('createSkill error:', error.message);
+    return { error: 'Failed to create skill' };
+  }
+
+  revalidatePath('/');
+  return { data: created };
+}
+
+export async function updateSkill(
+  id: string,
+  data: Partial<SkillInsert>
+): Promise<{ data?: Skill; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const { data: updated, error } = await supabase
+    .from('skills')
+    .update(data)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('updateSkill error:', error.message);
+    return { error: 'Failed to update skill' };
+  }
+
+  revalidatePath('/');
+  return { data: updated };
+}
+
+export async function deleteSkill(
+  id: string
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const { error } = await supabase.from('skills').delete().eq('id', id);
+
+  if (error) {
+    console.error('deleteSkill error:', error.message);
+    return { error: 'Failed to delete skill' };
+  }
+
+  revalidatePath('/');
+  return { data: { success: true } };
+}
+
+export async function reorderSkills(
+  orderedIds: string[]
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+  const updates = orderedIds.map((id, index) =>
+    supabase.from('skills').update({ sort_order: index }).eq('id', id)
+  );
+
+  const results = await Promise.all(updates);
+  const failed = results.find((r) => r.error);
+
+  if (failed?.error) {
+    console.error('reorderSkills error:', failed.error.message);
+    return { error: 'Failed to reorder skills' };
+  }
+
+  revalidatePath('/');
   return { data: { success: true } };
 }

--- a/actions/admin.ts
+++ b/actions/admin.ts
@@ -1,7 +1,14 @@
 'use server';
 
+import { revalidatePath } from 'next/cache';
 import { createClient } from '@/lib/supabase/server';
 import type { User } from '@supabase/supabase-js';
+import type {
+  ProfileInsert,
+  ProfileStatInsert,
+  Experience,
+  ExperienceInsert,
+} from '@/lib/supabase/types';
 
 type AdminResult = { user: User; error?: undefined } | { user?: undefined; error: string };
 
@@ -125,4 +132,161 @@ export async function getAdminStats(): Promise<{
       recentDownloadsList,
     },
   };
+}
+
+export async function updateProfile(
+  data: Partial<ProfileInsert>
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const { error: updateError } = await supabase.from('profile').update(data).eq('singleton', true);
+
+  if (updateError) {
+    console.error('updateProfile error:', updateError.message);
+    return { error: 'Failed to update profile' };
+  }
+
+  revalidatePath('/');
+
+  return { data: { success: true } };
+}
+
+export async function updateProfileStats(
+  stats: ProfileStatInsert[]
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  // Bulk replace: delete all existing stats, then insert new ones
+  const { error: deleteError } = await supabase.from('profile_stats').delete().gte('sort_order', 0);
+
+  if (deleteError) {
+    console.error('updateProfileStats delete error:', deleteError.message);
+    return { error: 'Failed to update stats' };
+  }
+
+  if (stats.length > 0) {
+    const { error: insertError } = await supabase.from('profile_stats').insert(stats);
+
+    if (insertError) {
+      console.error('updateProfileStats insert error:', insertError.message);
+      return { error: 'Failed to save new stats' };
+    }
+  }
+
+  revalidatePath('/');
+
+  return { data: { success: true } };
+}
+
+export async function createExperience(
+  data: ExperienceInsert
+): Promise<{ data?: Experience; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const { data: created, error: insertError } = await supabase
+    .from('experiences')
+    .insert(data)
+    .select()
+    .single();
+
+  if (insertError) {
+    console.error('createExperience error:', insertError.message);
+    return { error: 'Failed to create experience' };
+  }
+
+  revalidatePath('/');
+
+  return { data: created };
+}
+
+export async function updateExperience(
+  id: string,
+  data: Partial<ExperienceInsert>
+): Promise<{ data?: Experience; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const { data: updated, error: updateError } = await supabase
+    .from('experiences')
+    .update(data)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (updateError) {
+    console.error('updateExperience error:', updateError.message);
+    return { error: 'Failed to update experience' };
+  }
+
+  revalidatePath('/');
+
+  return { data: updated };
+}
+
+export async function deleteExperience(
+  id: string
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const { error: deleteError } = await supabase.from('experiences').delete().eq('id', id);
+
+  if (deleteError) {
+    console.error('deleteExperience error:', deleteError.message);
+    return { error: 'Failed to delete experience' };
+  }
+
+  revalidatePath('/');
+
+  return { data: { success: true } };
+}
+
+export async function reorderExperiences(
+  orderedIds: string[]
+): Promise<{ data?: { success: true }; error?: string }> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) {
+    return { error: adminResult.error };
+  }
+
+  const supabase = await createClient();
+
+  const updates = orderedIds.map((id, index) =>
+    supabase.from('experiences').update({ sort_order: index }).eq('id', id)
+  );
+
+  const results = await Promise.all(updates);
+  const failed = results.find((r) => r.error);
+
+  if (failed?.error) {
+    console.error('reorderExperiences error:', failed.error.message);
+    return { error: 'Failed to reorder experiences' };
+  }
+
+  revalidatePath('/');
+
+  return { data: { success: true } };
 }

--- a/app/admin/(dashboard)/error.tsx
+++ b/app/admin/(dashboard)/error.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { AlertTriangle } from 'lucide-react';
+
+export default function AdminError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error('Admin dashboard error:', error);
+  }, [error]);
+
+  return (
+    <div className="flex h-full items-center justify-center p-6">
+      <Card className="max-w-md">
+        <CardContent className="flex flex-col items-center gap-4 pt-6 text-center">
+          <AlertTriangle className="text-destructive size-10" />
+          <div>
+            <h2 className="text-lg font-semibold">Something went wrong</h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              An error occurred while loading this page. Please try again.
+            </p>
+          </div>
+          <Button onClick={reset}>Try Again</Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/experience/loading.tsx
+++ b/app/admin/(dashboard)/experience/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ExperienceLoading() {
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="mt-2 h-4 w-56" />
+        </div>
+        <Skeleton className="h-10 w-36" />
+      </div>
+
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-full" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-14 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/experience/page.tsx
+++ b/app/admin/(dashboard)/experience/page.tsx
@@ -1,0 +1,16 @@
+import { getExperiences } from '@/lib/supabase/queries';
+import ExperienceEditor from '@/components/admin/experience-editor';
+
+export default async function ExperienceEditorPage() {
+  const experiences = await getExperiences();
+
+  if (!experiences) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Failed to load experience data.</p>
+      </div>
+    );
+  }
+
+  return <ExperienceEditor experiences={experiences} />;
+}

--- a/app/admin/(dashboard)/loading.tsx
+++ b/app/admin/(dashboard)/loading.tsx
@@ -1,0 +1,60 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="mt-2 h-4 w-64" />
+      </div>
+
+      {/* Stats cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader className="flex flex-row items-center justify-between pb-2">
+              <Skeleton className="h-4 w-28" />
+              <Skeleton className="size-4 rounded" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-8 w-16" />
+              <Skeleton className="mt-2 h-3 w-32" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Recent downloads */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="mt-1 h-4 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* Quick actions */}
+      <div>
+        <Skeleton className="mb-4 h-6 w-32" />
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i}>
+              <CardHeader className="flex flex-row items-center gap-3 pb-2">
+                <Skeleton className="size-10 rounded-lg" />
+                <div className="space-y-1">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-3 w-36" />
+                </div>
+              </CardHeader>
+            </Card>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/profile/loading.tsx
+++ b/app/admin/(dashboard)/profile/loading.tsx
@@ -1,0 +1,35 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ProfileLoading() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <Skeleton className="h-8 w-36" />
+        <Skeleton className="mt-2 h-4 w-72" />
+      </div>
+
+      {/* Tab strip */}
+      <Skeleton className="h-10 w-64" />
+
+      {/* Form card */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-44" />
+          <Skeleton className="mt-1 h-4 w-64" />
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid gap-4 sm:grid-cols-2">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-24" />
+                <Skeleton className="h-10 w-full" />
+              </div>
+            ))}
+          </div>
+          <Skeleton className="h-10 w-40" />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/profile/page.tsx
+++ b/app/admin/(dashboard)/profile/page.tsx
@@ -1,0 +1,16 @@
+import { getProfile, getProfileStats } from '@/lib/supabase/queries';
+import ProfileForm from '@/components/admin/profile-form';
+
+export default async function ProfileEditorPage() {
+  const [profile, stats] = await Promise.all([getProfile(), getProfileStats()]);
+
+  if (!profile) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Failed to load profile data.</p>
+      </div>
+    );
+  }
+
+  return <ProfileForm profile={profile} stats={stats ?? []} />;
+}

--- a/app/admin/(dashboard)/projects/loading.tsx
+++ b/app/admin/(dashboard)/projects/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ProjectsLoading() {
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <Skeleton className="h-8 w-36" />
+          <Skeleton className="mt-2 h-4 w-60" />
+        </div>
+        <Skeleton className="h-10 w-32" />
+      </div>
+
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-full" />
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-14 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/projects/page.tsx
+++ b/app/admin/(dashboard)/projects/page.tsx
@@ -1,0 +1,16 @@
+import { getProjects, getProjectCategories } from '@/lib/supabase/queries';
+import ProjectsEditor from '@/components/admin/projects-editor';
+
+export default async function ProjectsEditorPage() {
+  const [projects, categories] = await Promise.all([getProjects(), getProjectCategories()]);
+
+  if (!projects) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Failed to load projects data.</p>
+      </div>
+    );
+  }
+
+  return <ProjectsEditor projects={projects} categories={categories ?? []} />;
+}

--- a/app/admin/(dashboard)/resume/loading.tsx
+++ b/app/admin/(dashboard)/resume/loading.tsx
@@ -1,0 +1,38 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function ResumeLoading() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="mt-2 h-4 w-64" />
+      </div>
+
+      {/* Current resume card */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-36" />
+          <Skeleton className="mt-1 h-4 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-36" />
+        </CardContent>
+      </Card>
+
+      {/* Download log */}
+      <Card>
+        <CardHeader>
+          <Skeleton className="h-5 w-32" />
+          <Skeleton className="mt-1 h-4 w-56" />
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-10 w-full" />
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/resume/page.tsx
+++ b/app/admin/(dashboard)/resume/page.tsx
@@ -1,0 +1,23 @@
+import { getProfile } from '@/lib/supabase/queries';
+import { getResumeDownloads } from '@/actions/admin';
+import ResumeManager from '@/components/admin/resume-manager';
+
+export default async function ResumeManagementPage() {
+  const [profile, downloadsResult] = await Promise.all([getProfile(), getResumeDownloads()]);
+
+  if (!profile) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Failed to load profile data.</p>
+      </div>
+    );
+  }
+
+  return (
+    <ResumeManager
+      resumeUrl={profile.resume_url}
+      updatedAt={profile.updated_at}
+      downloads={downloadsResult.data ?? []}
+    />
+  );
+}

--- a/app/admin/(dashboard)/skills/loading.tsx
+++ b/app/admin/(dashboard)/skills/loading.tsx
@@ -1,0 +1,31 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function SkillsLoading() {
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="mt-2 h-4 w-64" />
+        </div>
+        <Skeleton className="h-10 w-28" />
+      </div>
+
+      <div className="space-y-4">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <Skeleton className="h-5 w-32" />
+            </CardHeader>
+            <CardContent className="space-y-2">
+              {Array.from({ length: 4 }).map((_, j) => (
+                <Skeleton key={j} className="h-8 w-full" />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/skills/page.tsx
+++ b/app/admin/(dashboard)/skills/page.tsx
@@ -1,0 +1,16 @@
+import { getSkillGroups } from '@/lib/supabase/queries';
+import SkillsEditor from '@/components/admin/skills-editor';
+
+export default async function SkillsEditorPage() {
+  const groups = await getSkillGroups();
+
+  if (!groups) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Failed to load skills data.</p>
+      </div>
+    );
+  }
+
+  return <SkillsEditor groups={groups} />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,7 @@
   --accent: oklch(0.97 0.002 247);
   --accent-foreground: oklch(0.205 0.015 255);
   --destructive: oklch(0.577 0.245 27.325);
+  --success: oklch(0.45 0.18 155);
   --border: oklch(0.922 0.004 247);
   --input: oklch(0.922 0.004 247);
   --ring: oklch(0.708 0.01 255);
@@ -68,6 +69,7 @@
   --accent: oklch(0.22 0.012 255);
   --accent-foreground: oklch(0.96 0.005 255);
   --destructive: oklch(0.704 0.191 22.216);
+  --success: oklch(0.65 0.2 155);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
@@ -122,6 +124,7 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-success: var(--success);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);

--- a/components/admin/experience-editor.tsx
+++ b/components/admin/experience-editor.tsx
@@ -247,6 +247,7 @@ export default function ExperienceEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Move experience up"
                       onClick={() => handleMove(index, 'up')}
                       disabled={index === 0 || isReordering}
                     >
@@ -256,6 +257,7 @@ export default function ExperienceEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Move experience down"
                       onClick={() => handleMove(index, 'down')}
                       disabled={index === experiences.length - 1 || isReordering}
                     >
@@ -274,6 +276,7 @@ export default function ExperienceEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Edit experience"
                       onClick={() => openEditDialog(exp)}
                     >
                       <Pencil className="size-3" />
@@ -282,6 +285,7 @@ export default function ExperienceEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Delete experience"
                       onClick={() => openDeleteDialog(exp)}
                     >
                       <Trash2 className="size-3" />

--- a/components/admin/experience-editor.tsx
+++ b/components/admin/experience-editor.tsx
@@ -96,6 +96,18 @@ export default function ExperienceEditor({
     setIsSaving(true);
     setStatus(null);
 
+    if (
+      !formData.title.trim() ||
+      !formData.company.trim() ||
+      !formData.description.trim() ||
+      !formData.display_date.trim() ||
+      !formData.start_date.trim()
+    ) {
+      setStatus({ type: 'error', message: 'Please fill in all required fields' });
+      setIsSaving(false);
+      return;
+    }
+
     const payload = {
       title: formData.title,
       company: formData.company,
@@ -190,7 +202,7 @@ export default function ExperienceEditor({
       {status && (
         <p
           className={
-            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+            status.type === 'success' ? 'text-success text-sm' : 'text-destructive text-sm'
           }
         >
           {status.message}
@@ -282,7 +294,9 @@ export default function ExperienceEditor({
 
           <div className="space-y-4 py-4">
             <div className="space-y-2">
-              <Label htmlFor="exp-title">Title</Label>
+              <Label htmlFor="exp-title">
+                Title <span className="text-destructive">*</span>
+              </Label>
               <Input
                 id="exp-title"
                 value={formData.title}
@@ -292,7 +306,9 @@ export default function ExperienceEditor({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="exp-company">Company</Label>
+              <Label htmlFor="exp-company">
+                Company <span className="text-destructive">*</span>
+              </Label>
               <Input
                 id="exp-company"
                 value={formData.company}
@@ -302,7 +318,9 @@ export default function ExperienceEditor({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="exp-description">Description</Label>
+              <Label htmlFor="exp-description">
+                Description <span className="text-destructive">*</span>
+              </Label>
               <Textarea
                 id="exp-description"
                 value={formData.description}
@@ -313,7 +331,9 @@ export default function ExperienceEditor({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="exp-display-date">Display Date</Label>
+              <Label htmlFor="exp-display-date">
+                Display Date <span className="text-destructive">*</span>
+              </Label>
               <Input
                 id="exp-display-date"
                 value={formData.display_date}
@@ -324,7 +344,9 @@ export default function ExperienceEditor({
 
             <div className="grid gap-4 sm:grid-cols-2">
               <div className="space-y-2">
-                <Label htmlFor="exp-start-date">Start Date</Label>
+                <Label htmlFor="exp-start-date">
+                  Start Date <span className="text-destructive">*</span>
+                </Label>
                 <Input
                   id="exp-start-date"
                   type="date"

--- a/components/admin/experience-editor.tsx
+++ b/components/admin/experience-editor.tsx
@@ -1,0 +1,411 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Plus, Pencil, Trash2, ChevronUp, ChevronDown, Loader2 } from 'lucide-react';
+import {
+  createExperience,
+  updateExperience,
+  deleteExperience,
+  reorderExperiences,
+} from '@/actions/admin';
+import type { Experience } from '@/lib/supabase/types';
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+const EMPTY_FORM = {
+  title: '',
+  company: '',
+  description: '',
+  display_date: '',
+  start_date: '',
+  end_date: '',
+  icon: 'work',
+  company_logo_url: '',
+};
+
+export default function ExperienceEditor({
+  experiences: initialExperiences,
+}: {
+  experiences: Experience[];
+}) {
+  const [experiences, setExperiences] = useState(initialExperiences);
+  const [editingExp, setEditingExp] = useState<Experience | null>(null);
+  const [deletingExp, setDeletingExp] = useState<Experience | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [formData, setFormData] = useState(EMPTY_FORM);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isReordering, setIsReordering] = useState(false);
+  const [status, setStatus] = useState<StatusMessage>(null);
+
+  function openAddDialog() {
+    setEditingExp(null);
+    setFormData(EMPTY_FORM);
+    setIsDialogOpen(true);
+  }
+
+  function openEditDialog(exp: Experience) {
+    setEditingExp(exp);
+    setFormData({
+      title: exp.title,
+      company: exp.company,
+      description: exp.description,
+      display_date: exp.display_date,
+      start_date: exp.start_date,
+      end_date: exp.end_date ?? '',
+      icon: exp.icon,
+      company_logo_url: exp.company_logo_url ?? '',
+    });
+    setIsDialogOpen(true);
+  }
+
+  function openDeleteDialog(exp: Experience) {
+    setDeletingExp(exp);
+    setIsDeleteDialogOpen(true);
+  }
+
+  async function handleSave() {
+    setIsSaving(true);
+    setStatus(null);
+
+    const payload = {
+      title: formData.title,
+      company: formData.company,
+      description: formData.description,
+      display_date: formData.display_date,
+      start_date: formData.start_date,
+      end_date: formData.end_date || null,
+      icon: formData.icon,
+      company_logo_url: formData.company_logo_url || null,
+    };
+
+    if (editingExp) {
+      const { data, error } = await updateExperience(editingExp.id, payload);
+      if (error) {
+        setStatus({ type: 'error', message: error });
+      } else if (data) {
+        setExperiences((prev) => prev.map((e) => (e.id === data.id ? data : e)));
+        setStatus({ type: 'success', message: 'Experience updated successfully!' });
+        setIsDialogOpen(false);
+      }
+    } else {
+      const { data, error } = await createExperience({
+        ...payload,
+        sort_order: experiences.length,
+      });
+      if (error) {
+        setStatus({ type: 'error', message: error });
+      } else if (data) {
+        setExperiences((prev) => [...prev, data]);
+        setStatus({ type: 'success', message: 'Experience created successfully!' });
+        setIsDialogOpen(false);
+      }
+    }
+
+    setIsSaving(false);
+  }
+
+  async function handleDelete() {
+    if (!deletingExp) return;
+    setIsDeleting(true);
+    setStatus(null);
+
+    const { error } = await deleteExperience(deletingExp.id);
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    } else {
+      setExperiences((prev) => prev.filter((e) => e.id !== deletingExp.id));
+      setStatus({ type: 'success', message: 'Experience deleted successfully!' });
+      setIsDeleteDialogOpen(false);
+      setDeletingExp(null);
+    }
+
+    setIsDeleting(false);
+  }
+
+  async function handleMove(index: number, direction: 'up' | 'down') {
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= experiences.length) return;
+
+    setIsReordering(true);
+    setStatus(null);
+
+    const reordered = [...experiences];
+    [reordered[index], reordered[targetIndex]] = [reordered[targetIndex], reordered[index]];
+
+    setExperiences(reordered);
+
+    const { error } = await reorderExperiences(reordered.map((e) => e.id));
+    if (error) {
+      setExperiences(experiences); // revert
+      setStatus({ type: 'error', message: error });
+    }
+
+    setIsReordering(false);
+  }
+
+  const isAddMode = editingExp === null;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Experience Editor</h1>
+          <p className="text-muted-foreground text-sm">Manage your career timeline entries</p>
+        </div>
+        <Button onClick={openAddDialog}>
+          <Plus className="mr-1 size-4" />
+          Add Experience
+        </Button>
+      </div>
+
+      {status && (
+        <p
+          className={
+            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+          }
+        >
+          {status.message}
+        </p>
+      )}
+
+      {experiences.length === 0 ? (
+        <p className="text-muted-foreground py-16 text-center text-sm">
+          No experiences yet. Click &quot;Add Experience&quot; to create one.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[80px]">Order</TableHead>
+              <TableHead>Title</TableHead>
+              <TableHead>Company</TableHead>
+              <TableHead className="hidden sm:table-cell">Date</TableHead>
+              <TableHead className="w-[100px]">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {experiences.map((exp, index) => (
+              <TableRow key={exp.id}>
+                <TableCell>
+                  <div className="flex gap-0.5">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => handleMove(index, 'up')}
+                      disabled={index === 0 || isReordering}
+                    >
+                      <ChevronUp className="size-3" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => handleMove(index, 'down')}
+                      disabled={index === experiences.length - 1 || isReordering}
+                    >
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </div>
+                </TableCell>
+                <TableCell className="font-medium">{exp.title}</TableCell>
+                <TableCell>{exp.company}</TableCell>
+                <TableCell className="text-muted-foreground hidden sm:table-cell">
+                  {exp.display_date}
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-1">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => openEditDialog(exp)}
+                    >
+                      <Pencil className="size-3" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => openDeleteDialog(exp)}
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Add/Edit Dialog */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{isAddMode ? 'Add Experience' : 'Edit Experience'}</DialogTitle>
+            <DialogDescription>
+              {isAddMode
+                ? 'Add a new entry to your career timeline.'
+                : 'Update this career timeline entry.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="exp-title">Title</Label>
+              <Input
+                id="exp-title"
+                value={formData.title}
+                onChange={(e) => setFormData((p) => ({ ...p, title: e.target.value }))}
+                placeholder="Deputy Vice President"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="exp-company">Company</Label>
+              <Input
+                id="exp-company"
+                value={formData.company}
+                onChange={(e) => setFormData((p) => ({ ...p, company: e.target.value }))}
+                placeholder="HDFC Bank Limited"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="exp-description">Description</Label>
+              <Textarea
+                id="exp-description"
+                value={formData.description}
+                onChange={(e) => setFormData((p) => ({ ...p, description: e.target.value }))}
+                rows={3}
+                placeholder="Describe your role and responsibilities..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="exp-display-date">Display Date</Label>
+              <Input
+                id="exp-display-date"
+                value={formData.display_date}
+                onChange={(e) => setFormData((p) => ({ ...p, display_date: e.target.value }))}
+                placeholder="May 2023 - Present"
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="exp-start-date">Start Date</Label>
+                <Input
+                  id="exp-start-date"
+                  type="date"
+                  value={formData.start_date}
+                  onChange={(e) => setFormData((p) => ({ ...p, start_date: e.target.value }))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="exp-end-date">End Date</Label>
+                <Input
+                  id="exp-end-date"
+                  type="date"
+                  value={formData.end_date}
+                  onChange={(e) => setFormData((p) => ({ ...p, end_date: e.target.value }))}
+                />
+                <p className="text-muted-foreground text-xs">Leave empty for current role</p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="exp-icon">Icon</Label>
+                <Select
+                  value={formData.icon}
+                  onValueChange={(val) => setFormData((p) => ({ ...p, icon: val }))}
+                >
+                  <SelectTrigger id="exp-icon" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="work">Work (Briefcase)</SelectItem>
+                    <SelectItem value="react">React</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="exp-logo">Company Logo URL</Label>
+                <Input
+                  id="exp-logo"
+                  type="url"
+                  value={formData.company_logo_url}
+                  onChange={(e) => setFormData((p) => ({ ...p, company_logo_url: e.target.value }))}
+                  placeholder="/companies/logo.webp"
+                />
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isSaving ? 'Saving...' : isAddMode ? 'Create' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Experience</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &quot;{deletingExp?.title}&quot; at{' '}
+              {deletingExp?.company}? This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+              {isDeleting && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/admin/profile-form.tsx
+++ b/components/admin/profile-form.tsx
@@ -87,6 +87,17 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
     setIsSavingGeneral(true);
     setGeneralStatus(null);
 
+    if (
+      !formData.full_name.trim() ||
+      !formData.short_name.trim() ||
+      !formData.job_title.trim() ||
+      !formData.email.trim()
+    ) {
+      setGeneralStatus({ type: 'error', message: 'Please fill in all required fields' });
+      setIsSavingGeneral(false);
+      return;
+    }
+
     const { error } = await updateProfile({
       full_name: formData.full_name,
       short_name: formData.short_name,
@@ -203,7 +214,9 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                 <h3 className="text-sm font-semibold">Personal Info</h3>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="full_name">Full Name</Label>
+                    <Label htmlFor="full_name">
+                      Full Name <span className="text-destructive">*</span>
+                    </Label>
                     <Input
                       id="full_name"
                       value={formData.full_name}
@@ -211,7 +224,9 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                     />
                   </div>
                   <div className="space-y-2">
-                    <Label htmlFor="short_name">Short Name</Label>
+                    <Label htmlFor="short_name">
+                      Short Name <span className="text-destructive">*</span>
+                    </Label>
                     <Input
                       id="short_name"
                       value={formData.short_name}
@@ -220,7 +235,9 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                   </div>
                 </div>
                 <div className="space-y-2">
-                  <Label htmlFor="job_title">Job Title</Label>
+                  <Label htmlFor="job_title">
+                    Job Title <span className="text-destructive">*</span>
+                  </Label>
                   <Input
                     id="job_title"
                     value={formData.job_title}
@@ -283,7 +300,9 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                 <h3 className="text-sm font-semibold">Contact Info</h3>
                 <div className="grid gap-4 sm:grid-cols-2">
                   <div className="space-y-2">
-                    <Label htmlFor="email">Email</Label>
+                    <Label htmlFor="email">
+                      Email <span className="text-destructive">*</span>
+                    </Label>
                     <Input
                       id="email"
                       type="email"
@@ -358,7 +377,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                 <p
                   className={
                     generalStatus.type === 'success'
-                      ? 'text-sm text-green-600'
+                      ? 'text-success text-sm'
                       : 'text-destructive text-sm'
                   }
                 >
@@ -455,7 +474,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                 <p
                   className={
                     aboutStatus.type === 'success'
-                      ? 'text-sm text-green-600'
+                      ? 'text-success text-sm'
                       : 'text-destructive text-sm'
                   }
                 >
@@ -610,7 +629,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                 <p
                   className={
                     statsStatus.type === 'success'
-                      ? 'text-sm text-green-600'
+                      ? 'text-success text-sm'
                       : 'text-destructive text-sm'
                   }
                 >

--- a/components/admin/profile-form.tsx
+++ b/components/admin/profile-form.tsx
@@ -1,0 +1,631 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { Plus, Trash2, ChevronUp, ChevronDown, Loader2 } from 'lucide-react';
+import { updateProfile, updateProfileStats } from '@/actions/admin';
+import type { Profile, ProfileStat } from '@/lib/supabase/types';
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+interface ProfileFormProps {
+  profile: Profile;
+  stats: ProfileStat[];
+}
+
+export default function ProfileForm({ profile, stats }: ProfileFormProps) {
+  const [formData, setFormData] = useState({
+    full_name: profile.full_name,
+    short_name: profile.short_name,
+    job_title: profile.job_title,
+    tagline: profile.tagline ?? '',
+    typewriter_titles: profile.typewriter_titles,
+    email: profile.email,
+    phone: profile.phone ?? '',
+    location: profile.location ?? '',
+    linkedin_url: profile.linkedin_url ?? '',
+    github_url: profile.github_url ?? '',
+    footer_text: profile.footer_text ?? '',
+    about_tech_stack: profile.about_tech_stack ?? '',
+    about_current_focus: profile.about_current_focus ?? '',
+    about_beyond_code: profile.about_beyond_code ?? '',
+    about_expertise: profile.about_expertise ?? [],
+  });
+
+  const [statsData, setStatsData] = useState(
+    stats.map((s) => ({
+      id: s.id,
+      value: s.value,
+      suffix: s.suffix ?? '+',
+      label: s.label,
+      sort_order: s.sort_order,
+    }))
+  );
+
+  const [generalStatus, setGeneralStatus] = useState<StatusMessage>(null);
+  const [aboutStatus, setAboutStatus] = useState<StatusMessage>(null);
+  const [statsStatus, setStatsStatus] = useState<StatusMessage>(null);
+
+  const [isSavingGeneral, setIsSavingGeneral] = useState(false);
+  const [isSavingAbout, setIsSavingAbout] = useState(false);
+  const [isSavingStats, setIsSavingStats] = useState(false);
+
+  function updateField<K extends keyof typeof formData>(key: K, value: (typeof formData)[K]) {
+    setFormData((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function updateArrayItem(
+    key: 'typewriter_titles' | 'about_expertise',
+    index: number,
+    value: string
+  ) {
+    setFormData((prev) => {
+      const arr = [...prev[key]];
+      arr[index] = value;
+      return { ...prev, [key]: arr };
+    });
+  }
+
+  function addArrayItem(key: 'typewriter_titles' | 'about_expertise') {
+    setFormData((prev) => ({ ...prev, [key]: [...prev[key], ''] }));
+  }
+
+  function removeArrayItem(key: 'typewriter_titles' | 'about_expertise', index: number) {
+    setFormData((prev) => ({
+      ...prev,
+      [key]: prev[key].filter((_, i) => i !== index),
+    }));
+  }
+
+  async function handleSaveGeneral() {
+    setIsSavingGeneral(true);
+    setGeneralStatus(null);
+
+    const { error } = await updateProfile({
+      full_name: formData.full_name,
+      short_name: formData.short_name,
+      job_title: formData.job_title,
+      tagline: formData.tagline || null,
+      typewriter_titles: formData.typewriter_titles,
+      email: formData.email,
+      phone: formData.phone || null,
+      location: formData.location || null,
+      linkedin_url: formData.linkedin_url || null,
+      github_url: formData.github_url || null,
+      footer_text: formData.footer_text || null,
+    });
+
+    setGeneralStatus(
+      error
+        ? { type: 'error', message: error }
+        : { type: 'success', message: 'General info saved successfully!' }
+    );
+    setIsSavingGeneral(false);
+  }
+
+  async function handleSaveAbout() {
+    setIsSavingAbout(true);
+    setAboutStatus(null);
+
+    const { error } = await updateProfile({
+      about_tech_stack: formData.about_tech_stack || null,
+      about_current_focus: formData.about_current_focus || null,
+      about_beyond_code: formData.about_beyond_code || null,
+      about_expertise: formData.about_expertise.length > 0 ? formData.about_expertise : null,
+    });
+
+    setAboutStatus(
+      error
+        ? { type: 'error', message: error }
+        : { type: 'success', message: 'About info saved successfully!' }
+    );
+    setIsSavingAbout(false);
+  }
+
+  async function handleSaveStats() {
+    setIsSavingStats(true);
+    setStatsStatus(null);
+
+    const invalidStats = statsData.filter((s) => !s.label.trim());
+    if (invalidStats.length > 0) {
+      setStatsStatus({ type: 'error', message: 'All stats must have a label' });
+      setIsSavingStats(false);
+      return;
+    }
+
+    const statsToSave = statsData.map((s, index) => ({
+      value: s.value,
+      suffix: s.suffix || null,
+      label: s.label,
+      sort_order: index,
+    }));
+
+    const { error } = await updateProfileStats(statsToSave);
+
+    setStatsStatus(
+      error
+        ? { type: 'error', message: error }
+        : { type: 'success', message: 'Stats saved successfully!' }
+    );
+    setIsSavingStats(false);
+  }
+
+  function moveStatUp(index: number) {
+    if (index === 0) return;
+    setStatsData((prev) => {
+      const next = [...prev];
+      [next[index - 1], next[index]] = [next[index], next[index - 1]];
+      return next;
+    });
+  }
+
+  function moveStatDown(index: number) {
+    setStatsData((prev) => {
+      if (index === prev.length - 1) return prev;
+      const next = [...prev];
+      [next[index], next[index + 1]] = [next[index + 1], next[index]];
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold">Profile Editor</h1>
+        <p className="text-muted-foreground text-sm">
+          Edit your personal info, about section, and stats
+        </p>
+      </div>
+
+      <Tabs defaultValue="general" className="w-full">
+        <TabsList variant="line">
+          <TabsTrigger value="general">General</TabsTrigger>
+          <TabsTrigger value="about">About</TabsTrigger>
+          <TabsTrigger value="stats">Stats</TabsTrigger>
+        </TabsList>
+
+        {/* General Tab */}
+        <TabsContent value="general" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>General Information</CardTitle>
+              <CardDescription>Basic profile details and contact information</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              {/* Personal Info */}
+              <div className="space-y-4">
+                <h3 className="text-sm font-semibold">Personal Info</h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="full_name">Full Name</Label>
+                    <Input
+                      id="full_name"
+                      value={formData.full_name}
+                      onChange={(e) => updateField('full_name', e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="short_name">Short Name</Label>
+                    <Input
+                      id="short_name"
+                      value={formData.short_name}
+                      onChange={(e) => updateField('short_name', e.target.value)}
+                    />
+                  </div>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="job_title">Job Title</Label>
+                  <Input
+                    id="job_title"
+                    value={formData.job_title}
+                    onChange={(e) => updateField('job_title', e.target.value)}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="tagline">Tagline</Label>
+                  <Textarea
+                    id="tagline"
+                    value={formData.tagline}
+                    onChange={(e) => updateField('tagline', e.target.value)}
+                    rows={3}
+                  />
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Typewriter Titles */}
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold">Typewriter Titles</h3>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => addArrayItem('typewriter_titles')}
+                  >
+                    <Plus className="mr-1 size-4" />
+                    Add Title
+                  </Button>
+                </div>
+                <div className="space-y-2">
+                  {formData.typewriter_titles.map((title, index) => (
+                    <div key={index} className="flex gap-2">
+                      <Input
+                        value={title}
+                        onChange={(e) =>
+                          updateArrayItem('typewriter_titles', index, e.target.value)
+                        }
+                        placeholder={`Title ${index + 1}`}
+                      />
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => removeArrayItem('typewriter_titles', index)}
+                        disabled={formData.typewriter_titles.length === 1}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Contact Info */}
+              <div className="space-y-4">
+                <h3 className="text-sm font-semibold">Contact Info</h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="email">Email</Label>
+                    <Input
+                      id="email"
+                      type="email"
+                      value={formData.email}
+                      onChange={(e) => updateField('email', e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="phone">Phone</Label>
+                    <Input
+                      id="phone"
+                      type="tel"
+                      value={formData.phone}
+                      onChange={(e) => updateField('phone', e.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="location">Location</Label>
+                    <Input
+                      id="location"
+                      value={formData.location}
+                      onChange={(e) => updateField('location', e.target.value)}
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Social Links */}
+              <div className="space-y-4">
+                <h3 className="text-sm font-semibold">Social Links</h3>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-2">
+                    <Label htmlFor="linkedin_url">LinkedIn URL</Label>
+                    <Input
+                      id="linkedin_url"
+                      type="url"
+                      value={formData.linkedin_url}
+                      onChange={(e) => updateField('linkedin_url', e.target.value)}
+                      placeholder="https://linkedin.com/in/..."
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <Label htmlFor="github_url">GitHub URL</Label>
+                    <Input
+                      id="github_url"
+                      type="url"
+                      value={formData.github_url}
+                      onChange={(e) => updateField('github_url', e.target.value)}
+                      placeholder="https://github.com/..."
+                    />
+                  </div>
+                </div>
+              </div>
+
+              <Separator />
+
+              {/* Footer Text */}
+              <div className="space-y-2">
+                <Label htmlFor="footer_text">Footer Text</Label>
+                <Textarea
+                  id="footer_text"
+                  value={formData.footer_text}
+                  onChange={(e) => updateField('footer_text', e.target.value)}
+                  rows={2}
+                  placeholder="Built with..."
+                />
+              </div>
+
+              {generalStatus && (
+                <p
+                  className={
+                    generalStatus.type === 'success'
+                      ? 'text-sm text-green-600'
+                      : 'text-destructive text-sm'
+                  }
+                >
+                  {generalStatus.message}
+                </p>
+              )}
+
+              <Button onClick={handleSaveGeneral} disabled={isSavingGeneral}>
+                {isSavingGeneral && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {isSavingGeneral ? 'Saving...' : 'Save General Info'}
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* About Tab */}
+        <TabsContent value="about" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>About Section</CardTitle>
+              <CardDescription>Tell your story and showcase your expertise</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="space-y-2">
+                <Label htmlFor="about_tech_stack">Tech Stack</Label>
+                <Textarea
+                  id="about_tech_stack"
+                  value={formData.about_tech_stack}
+                  onChange={(e) => updateField('about_tech_stack', e.target.value)}
+                  rows={4}
+                  placeholder="Describe your core tech stack..."
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="about_current_focus">Current Focus</Label>
+                <Textarea
+                  id="about_current_focus"
+                  value={formData.about_current_focus}
+                  onChange={(e) => updateField('about_current_focus', e.target.value)}
+                  rows={3}
+                  placeholder="What are you currently focused on?"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="about_beyond_code">Beyond Code</Label>
+                <Textarea
+                  id="about_beyond_code"
+                  value={formData.about_beyond_code}
+                  onChange={(e) => updateField('about_beyond_code', e.target.value)}
+                  rows={3}
+                  placeholder="What do you do outside of coding?"
+                />
+              </div>
+
+              <Separator />
+
+              {/* Expertise Highlights */}
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <h3 className="text-sm font-semibold">Expertise Highlights</h3>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => addArrayItem('about_expertise')}
+                  >
+                    <Plus className="mr-1 size-4" />
+                    Add Item
+                  </Button>
+                </div>
+                <div className="space-y-2">
+                  {formData.about_expertise.map((item, index) => (
+                    <div key={index} className="flex gap-2">
+                      <Input
+                        value={item}
+                        onChange={(e) => updateArrayItem('about_expertise', index, e.target.value)}
+                        placeholder={`Expertise ${index + 1}`}
+                      />
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => removeArrayItem('about_expertise', index)}
+                        disabled={formData.about_expertise.length === 1}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {aboutStatus && (
+                <p
+                  className={
+                    aboutStatus.type === 'success'
+                      ? 'text-sm text-green-600'
+                      : 'text-destructive text-sm'
+                  }
+                >
+                  {aboutStatus.message}
+                </p>
+              )}
+
+              <Button onClick={handleSaveAbout} disabled={isSavingAbout}>
+                {isSavingAbout && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {isSavingAbout ? 'Saving...' : 'Save About Info'}
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        {/* Stats Tab */}
+        <TabsContent value="stats" className="mt-6">
+          <Card>
+            <CardHeader>
+              <CardTitle>Profile Stats</CardTitle>
+              <CardDescription>
+                Quick stats displayed in the about section (e.g. 15+ years, 50+ projects)
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-6">
+              <div className="flex items-center justify-between">
+                <p className="text-muted-foreground text-sm">
+                  {statsData.length} {statsData.length === 1 ? 'stat' : 'stats'}
+                </p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() =>
+                    setStatsData((prev) => [
+                      ...prev,
+                      {
+                        id: crypto.randomUUID(),
+                        value: 0,
+                        suffix: '+',
+                        label: '',
+                        sort_order: prev.length,
+                      },
+                    ])
+                  }
+                >
+                  <Plus className="mr-1 size-4" />
+                  Add Stat
+                </Button>
+              </div>
+
+              {statsData.length === 0 ? (
+                <p className="text-muted-foreground py-8 text-center text-sm">
+                  No stats yet. Click &quot;Add Stat&quot; to create one.
+                </p>
+              ) : (
+                <div className="space-y-3">
+                  {statsData.map((stat, index) => (
+                    <div
+                      key={stat.id}
+                      className="border-border flex items-center gap-3 rounded-lg border p-3"
+                    >
+                      {/* Reorder buttons */}
+                      <div className="flex flex-col gap-0.5">
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="size-6"
+                          onClick={() => moveStatUp(index)}
+                          disabled={index === 0}
+                        >
+                          <ChevronUp className="size-3" />
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="size-6"
+                          onClick={() => moveStatDown(index)}
+                          disabled={index === statsData.length - 1}
+                        >
+                          <ChevronDown className="size-3" />
+                        </Button>
+                      </div>
+
+                      {/* Stat fields */}
+                      <div className="grid flex-1 gap-3 sm:grid-cols-4">
+                        <div className="space-y-1">
+                          <Label htmlFor={`stat-value-${stat.id}`} className="text-xs">
+                            Value
+                          </Label>
+                          <Input
+                            id={`stat-value-${stat.id}`}
+                            type="number"
+                            value={stat.value}
+                            onChange={(e) => {
+                              const val = parseInt(e.target.value) || 0;
+                              setStatsData((prev) =>
+                                prev.map((s, i) => (i === index ? { ...s, value: val } : s))
+                              );
+                            }}
+                          />
+                        </div>
+                        <div className="space-y-1">
+                          <Label htmlFor={`stat-suffix-${stat.id}`} className="text-xs">
+                            Suffix
+                          </Label>
+                          <Input
+                            id={`stat-suffix-${stat.id}`}
+                            value={stat.suffix}
+                            onChange={(e) =>
+                              setStatsData((prev) =>
+                                prev.map((s, i) =>
+                                  i === index ? { ...s, suffix: e.target.value } : s
+                                )
+                              )
+                            }
+                            placeholder="+"
+                          />
+                        </div>
+                        <div className="space-y-1 sm:col-span-2">
+                          <Label htmlFor={`stat-label-${stat.id}`} className="text-xs">
+                            Label
+                          </Label>
+                          <Input
+                            id={`stat-label-${stat.id}`}
+                            value={stat.label}
+                            onChange={(e) =>
+                              setStatsData((prev) =>
+                                prev.map((s, i) =>
+                                  i === index ? { ...s, label: e.target.value } : s
+                                )
+                              )
+                            }
+                            placeholder="Years of experience"
+                          />
+                        </div>
+                      </div>
+
+                      {/* Delete button */}
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => setStatsData((prev) => prev.filter((_, i) => i !== index))}
+                      >
+                        <Trash2 className="size-4" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {statsStatus && (
+                <p
+                  className={
+                    statsStatus.type === 'success'
+                      ? 'text-sm text-green-600'
+                      : 'text-destructive text-sm'
+                  }
+                >
+                  {statsStatus.message}
+                </p>
+              )}
+
+              <Button onClick={handleSaveStats} disabled={isSavingStats}>
+                {isSavingStats && <Loader2 className="mr-2 size-4 animate-spin" />}
+                {isSavingStats ? 'Saving...' : 'Save Stats'}
+              </Button>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/components/admin/profile-form.tsx
+++ b/components/admin/profile-form.tsx
@@ -461,7 +461,6 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                         size="icon"
                         variant="ghost"
                         onClick={() => removeArrayItem('about_expertise', index)}
-                        disabled={formData.about_expertise.length === 1}
                       >
                         <Trash2 className="size-4" />
                       </Button>

--- a/components/admin/profile-form.tsx
+++ b/components/admin/profile-form.tsx
@@ -98,45 +98,65 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
       return;
     }
 
-    const { error } = await updateProfile({
-      full_name: formData.full_name,
-      short_name: formData.short_name,
-      job_title: formData.job_title,
-      tagline: formData.tagline || null,
-      typewriter_titles: formData.typewriter_titles,
-      email: formData.email,
-      phone: formData.phone || null,
-      location: formData.location || null,
-      linkedin_url: formData.linkedin_url || null,
-      github_url: formData.github_url || null,
-      footer_text: formData.footer_text || null,
-    });
+    const cleanedTitles = formData.typewriter_titles.map((t) => t.trim()).filter(Boolean);
 
-    setGeneralStatus(
-      error
-        ? { type: 'error', message: error }
-        : { type: 'success', message: 'General info saved successfully!' }
-    );
-    setIsSavingGeneral(false);
+    try {
+      const { error } = await updateProfile({
+        full_name: formData.full_name,
+        short_name: formData.short_name,
+        job_title: formData.job_title,
+        tagline: formData.tagline || null,
+        typewriter_titles: cleanedTitles.length > 0 ? cleanedTitles : [],
+        email: formData.email,
+        phone: formData.phone || null,
+        location: formData.location || null,
+        linkedin_url: formData.linkedin_url || null,
+        github_url: formData.github_url || null,
+        footer_text: formData.footer_text || null,
+      });
+
+      setGeneralStatus(
+        error
+          ? { type: 'error', message: error }
+          : { type: 'success', message: 'General info saved successfully!' }
+      );
+    } catch (err) {
+      setGeneralStatus({
+        type: 'error',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred',
+      });
+    } finally {
+      setIsSavingGeneral(false);
+    }
   }
 
   async function handleSaveAbout() {
     setIsSavingAbout(true);
     setAboutStatus(null);
 
-    const { error } = await updateProfile({
-      about_tech_stack: formData.about_tech_stack || null,
-      about_current_focus: formData.about_current_focus || null,
-      about_beyond_code: formData.about_beyond_code || null,
-      about_expertise: formData.about_expertise.length > 0 ? formData.about_expertise : null,
-    });
+    const cleanedExpertise = formData.about_expertise.map((e) => e.trim()).filter(Boolean);
 
-    setAboutStatus(
-      error
-        ? { type: 'error', message: error }
-        : { type: 'success', message: 'About info saved successfully!' }
-    );
-    setIsSavingAbout(false);
+    try {
+      const { error } = await updateProfile({
+        about_tech_stack: formData.about_tech_stack || null,
+        about_current_focus: formData.about_current_focus || null,
+        about_beyond_code: formData.about_beyond_code || null,
+        about_expertise: cleanedExpertise.length > 0 ? cleanedExpertise : null,
+      });
+
+      setAboutStatus(
+        error
+          ? { type: 'error', message: error }
+          : { type: 'success', message: 'About info saved successfully!' }
+      );
+    } catch (err) {
+      setAboutStatus({
+        type: 'error',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred',
+      });
+    } finally {
+      setIsSavingAbout(false);
+    }
   }
 
   async function handleSaveStats() {
@@ -157,14 +177,22 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
       sort_order: index,
     }));
 
-    const { error } = await updateProfileStats(statsToSave);
+    try {
+      const { error } = await updateProfileStats(statsToSave);
 
-    setStatsStatus(
-      error
-        ? { type: 'error', message: error }
-        : { type: 'success', message: 'Stats saved successfully!' }
-    );
-    setIsSavingStats(false);
+      setStatsStatus(
+        error
+          ? { type: 'error', message: error }
+          : { type: 'success', message: 'Stats saved successfully!' }
+      );
+    } catch (err) {
+      setStatsStatus({
+        type: 'error',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred',
+      });
+    } finally {
+      setIsSavingStats(false);
+    }
   }
 
   function moveStatUp(index: number) {
@@ -283,6 +311,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                       <Button
                         size="icon"
                         variant="ghost"
+                        aria-label={`Delete title ${index + 1}`}
                         onClick={() => removeArrayItem('typewriter_titles', index)}
                         disabled={formData.typewriter_titles.length === 1}
                       >
@@ -460,6 +489,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                       <Button
                         size="icon"
                         variant="ghost"
+                        aria-label={`Delete expertise ${index + 1}`}
                         onClick={() => removeArrayItem('about_expertise', index)}
                       >
                         <Trash2 className="size-4" />
@@ -541,6 +571,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                           size="icon"
                           variant="ghost"
                           className="size-6"
+                          aria-label="Move stat up"
                           onClick={() => moveStatUp(index)}
                           disabled={index === 0}
                         >
@@ -550,6 +581,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                           size="icon"
                           variant="ghost"
                           className="size-6"
+                          aria-label="Move stat down"
                           onClick={() => moveStatDown(index)}
                           disabled={index === statsData.length - 1}
                         >
@@ -615,6 +647,7 @@ export default function ProfileForm({ profile, stats }: ProfileFormProps) {
                       <Button
                         size="icon"
                         variant="ghost"
+                        aria-label="Delete stat"
                         onClick={() => setStatsData((prev) => prev.filter((_, i) => i !== index))}
                       >
                         <Trash2 className="size-4" />

--- a/components/admin/projects-editor.tsx
+++ b/components/admin/projects-editor.tsx
@@ -1,0 +1,436 @@
+'use client';
+
+import React, { useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Plus, Pencil, Trash2, ChevronUp, ChevronDown, Loader2 } from 'lucide-react';
+import { createProject, updateProject, deleteProject, reorderProjects } from '@/actions/admin';
+import type { Project, ProjectCategory } from '@/lib/supabase/types';
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+const NO_CATEGORY = '__none__';
+
+const EMPTY_FORM = {
+  title: '',
+  description: '',
+  tags: '',
+  category_id: NO_CATEGORY,
+  image_url: '',
+  demo_video_url: '',
+  source_code_url: '',
+  live_site_url: '',
+};
+
+export default function ProjectsEditor({
+  projects: initialProjects,
+  categories,
+}: {
+  projects: Project[];
+  categories: ProjectCategory[];
+}) {
+  const [projects, setProjects] = useState(initialProjects);
+  const [editingProject, setEditingProject] = useState<Project | null>(null);
+  const [deletingProject, setDeletingProject] = useState<Project | null>(null);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [formData, setFormData] = useState(EMPTY_FORM);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [isReordering, setIsReordering] = useState(false);
+  const [status, setStatus] = useState<StatusMessage>(null);
+
+  const categoryMap = new Map(categories.map((c) => [c.id, c.name]));
+
+  function openAddDialog() {
+    setEditingProject(null);
+    setFormData(EMPTY_FORM);
+    setIsDialogOpen(true);
+  }
+
+  function openEditDialog(project: Project) {
+    setEditingProject(project);
+    setFormData({
+      title: project.title,
+      description: project.description,
+      tags: project.tags.join(', '),
+      category_id: project.category_id ?? NO_CATEGORY,
+      image_url: project.image_url ?? '',
+      demo_video_url: project.demo_video_url ?? '',
+      source_code_url: project.source_code_url ?? '',
+      live_site_url: project.live_site_url ?? '',
+    });
+    setIsDialogOpen(true);
+  }
+
+  function openDeleteDialog(project: Project) {
+    setDeletingProject(project);
+    setIsDeleteDialogOpen(true);
+  }
+
+  function parseTags(input: string): string[] {
+    return input
+      .split(',')
+      .map((t) => t.trim())
+      .filter(Boolean);
+  }
+
+  async function handleSave() {
+    setIsSaving(true);
+    setStatus(null);
+
+    const payload = {
+      title: formData.title,
+      description: formData.description,
+      tags: parseTags(formData.tags),
+      category_id: formData.category_id === NO_CATEGORY ? null : formData.category_id,
+      image_url: formData.image_url || null,
+      demo_video_url: formData.demo_video_url || null,
+      source_code_url: formData.source_code_url || null,
+      live_site_url: formData.live_site_url || null,
+    };
+
+    if (editingProject) {
+      const { data, error } = await updateProject(editingProject.id, payload);
+      if (error) {
+        setStatus({ type: 'error', message: error });
+      } else if (data) {
+        setProjects((prev) => prev.map((p) => (p.id === data.id ? data : p)));
+        setStatus({ type: 'success', message: 'Project updated successfully!' });
+        setIsDialogOpen(false);
+      }
+    } else {
+      const { data, error } = await createProject({
+        ...payload,
+        sort_order: projects.length,
+      });
+      if (error) {
+        setStatus({ type: 'error', message: error });
+      } else if (data) {
+        setProjects((prev) => [...prev, data]);
+        setStatus({ type: 'success', message: 'Project created successfully!' });
+        setIsDialogOpen(false);
+      }
+    }
+
+    setIsSaving(false);
+  }
+
+  async function handleDelete() {
+    if (!deletingProject) return;
+    setIsDeleting(true);
+    setStatus(null);
+
+    const { error } = await deleteProject(deletingProject.id);
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    } else {
+      setProjects((prev) => prev.filter((p) => p.id !== deletingProject.id));
+      setStatus({ type: 'success', message: 'Project deleted successfully!' });
+      setIsDeleteDialogOpen(false);
+      setDeletingProject(null);
+    }
+
+    setIsDeleting(false);
+  }
+
+  async function handleMove(index: number, direction: 'up' | 'down') {
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= projects.length) return;
+
+    setIsReordering(true);
+    setStatus(null);
+
+    const reordered = [...projects];
+    [reordered[index], reordered[targetIndex]] = [reordered[targetIndex], reordered[index]];
+
+    const snapshot = projects;
+    setProjects(reordered);
+
+    const { error } = await reorderProjects(reordered.map((p) => p.id));
+    if (error) {
+      setProjects(snapshot);
+      setStatus({ type: 'error', message: error });
+    }
+
+    setIsReordering(false);
+  }
+
+  const isAddMode = editingProject === null;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Projects Editor</h1>
+          <p className="text-muted-foreground text-sm">Manage your portfolio projects</p>
+        </div>
+        <Button onClick={openAddDialog}>
+          <Plus className="mr-1 size-4" />
+          Add Project
+        </Button>
+      </div>
+
+      {status && (
+        <p
+          className={
+            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+          }
+        >
+          {status.message}
+        </p>
+      )}
+
+      {projects.length === 0 ? (
+        <p className="text-muted-foreground py-16 text-center text-sm">
+          No projects yet. Click &quot;Add Project&quot; to create one.
+        </p>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[80px]">Order</TableHead>
+              <TableHead>Title</TableHead>
+              <TableHead className="hidden sm:table-cell">Category</TableHead>
+              <TableHead className="hidden md:table-cell">Tags</TableHead>
+              <TableHead className="w-[100px]">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {projects.map((project, index) => (
+              <TableRow key={project.id}>
+                <TableCell>
+                  <div className="flex gap-0.5">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => handleMove(index, 'up')}
+                      disabled={index === 0 || isReordering}
+                    >
+                      <ChevronUp className="size-3" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => handleMove(index, 'down')}
+                      disabled={index === projects.length - 1 || isReordering}
+                    >
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </div>
+                </TableCell>
+                <TableCell className="font-medium">{project.title}</TableCell>
+                <TableCell className="text-muted-foreground hidden sm:table-cell">
+                  {categoryMap.get(project.category_id ?? '') ?? '—'}
+                </TableCell>
+                <TableCell className="hidden md:table-cell">
+                  <div className="flex flex-wrap gap-1">
+                    {project.tags.slice(0, 3).map((tag) => (
+                      <Badge key={tag} variant="secondary" className="text-xs">
+                        {tag}
+                      </Badge>
+                    ))}
+                    {project.tags.length > 3 && (
+                      <Badge variant="secondary" className="text-xs">
+                        +{project.tags.length - 3}
+                      </Badge>
+                    )}
+                  </div>
+                </TableCell>
+                <TableCell>
+                  <div className="flex gap-1">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => openEditDialog(project)}
+                    >
+                      <Pencil className="size-3" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => openDeleteDialog(project)}
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+
+      {/* Add/Edit Dialog */}
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>{isAddMode ? 'Add Project' : 'Edit Project'}</DialogTitle>
+            <DialogDescription>
+              {isAddMode ? 'Add a new project to your portfolio.' : 'Update this project.'}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="proj-title">Title</Label>
+              <Input
+                id="proj-title"
+                value={formData.title}
+                onChange={(e) => setFormData((p) => ({ ...p, title: e.target.value }))}
+                placeholder="My Awesome Project"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="proj-description">Description</Label>
+              <Textarea
+                id="proj-description"
+                value={formData.description}
+                onChange={(e) => setFormData((p) => ({ ...p, description: e.target.value }))}
+                rows={3}
+                placeholder="A brief description of the project..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="proj-tags">Tags</Label>
+              <Input
+                id="proj-tags"
+                value={formData.tags}
+                onChange={(e) => setFormData((p) => ({ ...p, tags: e.target.value }))}
+                placeholder="React, TypeScript, Next.js"
+              />
+              <p className="text-muted-foreground text-xs">Comma-separated list</p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="proj-category">Category</Label>
+              <Select
+                value={formData.category_id}
+                onValueChange={(val) => setFormData((p) => ({ ...p, category_id: val }))}
+              >
+                <SelectTrigger id="proj-category" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value={NO_CATEGORY}>No Category</SelectItem>
+                  {categories.map((cat) => (
+                    <SelectItem key={cat.id} value={cat.id}>
+                      {cat.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="proj-image">Image URL</Label>
+              <Input
+                id="proj-image"
+                value={formData.image_url}
+                onChange={(e) => setFormData((p) => ({ ...p, image_url: e.target.value }))}
+                placeholder="/images/project.png or https://..."
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="proj-video">Demo Video URL</Label>
+              <Input
+                id="proj-video"
+                value={formData.demo_video_url}
+                onChange={(e) => setFormData((p) => ({ ...p, demo_video_url: e.target.value }))}
+                placeholder="Optional video URL"
+              />
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="proj-source">Source Code URL</Label>
+                <Input
+                  id="proj-source"
+                  type="url"
+                  value={formData.source_code_url}
+                  onChange={(e) => setFormData((p) => ({ ...p, source_code_url: e.target.value }))}
+                  placeholder="https://github.com/..."
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="proj-live">Live Site URL</Label>
+                <Input
+                  id="proj-live"
+                  type="url"
+                  value={formData.live_site_url}
+                  onChange={(e) => setFormData((p) => ({ ...p, live_site_url: e.target.value }))}
+                  placeholder="https://..."
+                />
+              </div>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={isSaving}>
+              {isSaving && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isSaving ? 'Saving...' : isAddMode ? 'Create' : 'Save Changes'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Confirmation Dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Project</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &quot;{deletingProject?.title}&quot;? This action
+              cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={isDeleting}>
+              {isDeleting && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/admin/projects-editor.tsx
+++ b/components/admin/projects-editor.tsx
@@ -105,6 +105,12 @@ export default function ProjectsEditor({
     setIsSaving(true);
     setStatus(null);
 
+    if (!formData.title.trim() || !formData.description.trim()) {
+      setStatus({ type: 'error', message: 'Please fill in all required fields' });
+      setIsSaving(false);
+      return;
+    }
+
     const payload = {
       title: formData.title,
       description: formData.description,
@@ -200,7 +206,7 @@ export default function ProjectsEditor({
       {status && (
         <p
           className={
-            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+            status.type === 'success' ? 'text-success text-sm' : 'text-destructive text-sm'
           }
         >
           {status.message}
@@ -303,7 +309,9 @@ export default function ProjectsEditor({
 
           <div className="space-y-4 py-4">
             <div className="space-y-2">
-              <Label htmlFor="proj-title">Title</Label>
+              <Label htmlFor="proj-title">
+                Title <span className="text-destructive">*</span>
+              </Label>
               <Input
                 id="proj-title"
                 value={formData.title}
@@ -313,7 +321,9 @@ export default function ProjectsEditor({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="proj-description">Description</Label>
+              <Label htmlFor="proj-description">
+                Description <span className="text-destructive">*</span>
+              </Label>
               <Textarea
                 id="proj-description"
                 value={formData.description}

--- a/components/admin/projects-editor.tsx
+++ b/components/admin/projects-editor.tsx
@@ -250,6 +250,7 @@ export default function ProjectsEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Move project up"
                       onClick={() => handleMove(index, 'up')}
                       disabled={index === 0 || isReordering}
                     >
@@ -259,6 +260,7 @@ export default function ProjectsEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Move project down"
                       onClick={() => handleMove(index, 'down')}
                       disabled={index === projects.length - 1 || isReordering}
                     >
@@ -272,8 +274,8 @@ export default function ProjectsEditor({
                 </TableCell>
                 <TableCell className="hidden md:table-cell">
                   <div className="flex flex-wrap gap-1">
-                    {project.tags.slice(0, 3).map((tag) => (
-                      <Badge key={tag} variant="secondary" className="text-xs">
+                    {project.tags.slice(0, 3).map((tag, i) => (
+                      <Badge key={`${tag}-${i}`} variant="secondary" className="text-xs">
                         {tag}
                       </Badge>
                     ))}
@@ -290,6 +292,7 @@ export default function ProjectsEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Edit project"
                       onClick={() => openEditDialog(project)}
                     >
                       <Pencil className="size-3" />
@@ -298,6 +301,7 @@ export default function ProjectsEditor({
                       size="icon"
                       variant="ghost"
                       className="size-7"
+                      aria-label="Delete project"
                       onClick={() => openDeleteDialog(project)}
                     >
                       <Trash2 className="size-3" />

--- a/components/admin/resume-manager.tsx
+++ b/components/admin/resume-manager.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+import React, { useRef, useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { FileUp, FileText, Loader2 } from 'lucide-react';
+import { uploadResume } from '@/actions/admin';
+import type { ResumeDownloadEntry } from '@/actions/admin';
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+export default function ResumeManager({
+  resumeUrl,
+  updatedAt,
+  downloads,
+}: {
+  resumeUrl: string | null;
+  updatedAt: string;
+  downloads: ResumeDownloadEntry[];
+}) {
+  const [currentResumeUrl, setCurrentResumeUrl] = useState(resumeUrl);
+  const [isUploading, setIsUploading] = useState(false);
+  const [status, setStatus] = useState<StatusMessage>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    setStatus(null);
+
+    const formData = new FormData();
+    formData.append('file', file);
+
+    const { data, error } = await uploadResume(formData);
+
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    } else if (data) {
+      setCurrentResumeUrl(data.path);
+      setStatus({ type: 'success', message: 'Resume uploaded successfully!' });
+    }
+
+    setIsUploading(false);
+
+    // Reset file input so the same file can be re-selected
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold">Resume Management</h1>
+        <p className="text-muted-foreground text-sm">
+          Upload your resume and view download history
+        </p>
+      </div>
+
+      {status && (
+        <p
+          className={
+            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+          }
+        >
+          {status.message}
+        </p>
+      )}
+
+      {/* Current Resume Card */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Current Resume</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center gap-3">
+            <FileText className="text-muted-foreground size-8" />
+            <div>
+              {currentResumeUrl ? (
+                <>
+                  <p className="font-medium">{currentResumeUrl}</p>
+                  <p className="text-muted-foreground text-xs">
+                    Last updated: {new Date(updatedAt).toLocaleDateString()}
+                  </p>
+                </>
+              ) : (
+                <p className="text-muted-foreground">No resume uploaded</p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".pdf,application/pdf"
+              className="hidden"
+              onChange={handleUpload}
+              disabled={isUploading}
+            />
+            <Button
+              onClick={() => fileInputRef.current?.click()}
+              disabled={isUploading}
+              variant={currentResumeUrl ? 'outline' : 'default'}
+            >
+              {isUploading ? (
+                <Loader2 className="mr-2 size-4 animate-spin" />
+              ) : (
+                <FileUp className="mr-2 size-4" />
+              )}
+              {isUploading ? 'Uploading...' : currentResumeUrl ? 'Replace Resume' : 'Upload Resume'}
+            </Button>
+            <p className="text-muted-foreground mt-1 text-xs">PDF only, max 10 MB</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Download Log */}
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Download Log</h2>
+
+        {downloads.length === 0 ? (
+          <p className="text-muted-foreground py-8 text-center text-sm">
+            No downloads recorded yet.
+          </p>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead className="hidden sm:table-cell">Email</TableHead>
+                <TableHead className="hidden md:table-cell">Company</TableHead>
+                <TableHead className="w-[120px]">Downloaded</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {downloads.map((dl) => (
+                <TableRow key={dl.id}>
+                  <TableCell className="font-medium">{dl.visitorName ?? '—'}</TableCell>
+                  <TableCell className="text-muted-foreground hidden sm:table-cell">
+                    {dl.visitorEmail ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground hidden md:table-cell">
+                    {dl.visitorCompany ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {timeAgo(dl.downloadedAt)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/resume-manager.tsx
+++ b/components/admin/resume-manager.tsx
@@ -63,23 +63,26 @@ export default function ResumeManager({
     setIsUploading(true);
     setStatus(null);
 
-    const formData = new FormData();
-    formData.append('file', file);
+    try {
+      const formData = new FormData();
+      formData.append('file', file);
 
-    const { data, error } = await uploadResume(formData);
+      const { data, error } = await uploadResume(formData);
 
-    if (error) {
-      setStatus({ type: 'error', message: error });
-    } else if (data) {
-      setCurrentResumeUrl(data.path);
-      setStatus({ type: 'success', message: 'Resume uploaded successfully!' });
-    }
-
-    setIsUploading(false);
-
-    // Reset file input so the same file can be re-selected
-    if (fileInputRef.current) {
-      fileInputRef.current.value = '';
+      if (error) {
+        setStatus({ type: 'error', message: error });
+      } else if (data) {
+        setCurrentResumeUrl(data.path);
+        setStatus({ type: 'success', message: 'Resume uploaded successfully!' });
+      }
+    } catch (err) {
+      setStatus({
+        type: 'error',
+        message: err instanceof Error ? err.message : 'An unexpected error occurred',
+      });
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
     }
   }
 

--- a/components/admin/resume-manager.tsx
+++ b/components/admin/resume-manager.tsx
@@ -48,6 +48,18 @@ export default function ResumeManager({
     const file = e.target.files?.[0];
     if (!file) return;
 
+    if (file.type !== 'application/pdf') {
+      setStatus({ type: 'error', message: 'Only PDF files are allowed' });
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      return;
+    }
+
+    if (file.size > 10 * 1024 * 1024) {
+      setStatus({ type: 'error', message: 'File must be smaller than 10 MB' });
+      if (fileInputRef.current) fileInputRef.current.value = '';
+      return;
+    }
+
     setIsUploading(true);
     setStatus(null);
 
@@ -83,7 +95,7 @@ export default function ResumeManager({
       {status && (
         <p
           className={
-            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+            status.type === 'success' ? 'text-success text-sm' : 'text-destructive text-sm'
           }
         >
           {status.message}

--- a/components/admin/skills-editor.tsx
+++ b/components/admin/skills-editor.tsx
@@ -264,7 +264,7 @@ export default function SkillsEditor({
       {status && (
         <p
           className={
-            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+            status.type === 'success' ? 'text-success text-sm' : 'text-destructive text-sm'
           }
         >
           {status.message}

--- a/components/admin/skills-editor.tsx
+++ b/components/admin/skills-editor.tsx
@@ -1,0 +1,523 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent, CardAction } from '@/components/ui/card';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Button } from '@/components/ui/button';
+import { Plus, Pencil, Trash2, ChevronUp, ChevronDown, Loader2, Check, X } from 'lucide-react';
+import {
+  createSkillGroup,
+  updateSkillGroup,
+  deleteSkillGroup,
+  reorderSkillGroups,
+  createSkill,
+  updateSkill,
+  deleteSkill,
+  reorderSkills,
+} from '@/actions/admin';
+import type { SkillGroupWithSkills, SkillGroup, Skill } from '@/lib/supabase/types';
+
+type StatusMessage = { type: 'success' | 'error'; message: string } | null;
+
+export default function SkillsEditor({
+  groups: initialGroups,
+}: {
+  groups: SkillGroupWithSkills[];
+}) {
+  const [groups, setGroups] = useState(initialGroups);
+
+  // Group dialog state
+  const [isGroupDialogOpen, setIsGroupDialogOpen] = useState(false);
+  const [editingGroup, setEditingGroup] = useState<SkillGroup | null>(null);
+  const [groupName, setGroupName] = useState('');
+
+  // Delete dialog state
+  const [deletingGroup, setDeletingGroup] = useState<SkillGroupWithSkills | null>(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+
+  // Inline skill editing state
+  const [newSkillName, setNewSkillName] = useState<Record<string, string>>({});
+  const [editingSkillId, setEditingSkillId] = useState<string | null>(null);
+  const [editingSkillName, setEditingSkillName] = useState('');
+
+  // Loading states
+  const [isSavingGroup, setIsSavingGroup] = useState(false);
+  const [isDeletingGroup, setIsDeletingGroup] = useState(false);
+  const [isReorderingGroups, setIsReorderingGroups] = useState(false);
+  const [savingSkillId, setSavingSkillId] = useState<string | null>(null);
+  const [status, setStatus] = useState<StatusMessage>(null);
+
+  // --- Group operations ---
+
+  function openAddGroupDialog() {
+    setEditingGroup(null);
+    setGroupName('');
+    setIsGroupDialogOpen(true);
+  }
+
+  function openEditGroupDialog(group: SkillGroup) {
+    setEditingGroup(group);
+    setGroupName(group.category);
+    setIsGroupDialogOpen(true);
+  }
+
+  function openDeleteGroupDialog(group: SkillGroupWithSkills) {
+    setDeletingGroup(group);
+    setIsDeleteDialogOpen(true);
+  }
+
+  async function handleSaveGroup() {
+    if (!groupName.trim()) return;
+    setIsSavingGroup(true);
+    setStatus(null);
+
+    if (editingGroup) {
+      const { data, error } = await updateSkillGroup(editingGroup.id, {
+        category: groupName.trim(),
+      });
+      if (error) {
+        setStatus({ type: 'error', message: error });
+      } else if (data) {
+        setGroups((prev) =>
+          prev.map((g) => (g.id === data.id ? { ...g, category: data.category } : g))
+        );
+        setStatus({ type: 'success', message: 'Group updated!' });
+        setIsGroupDialogOpen(false);
+      }
+    } else {
+      const { data, error } = await createSkillGroup({
+        category: groupName.trim(),
+        sort_order: groups.length,
+      });
+      if (error) {
+        setStatus({ type: 'error', message: error });
+      } else if (data) {
+        setGroups((prev) => [...prev, { ...data, skills: [] }]);
+        setStatus({ type: 'success', message: 'Group created!' });
+        setIsGroupDialogOpen(false);
+      }
+    }
+
+    setIsSavingGroup(false);
+  }
+
+  async function handleDeleteGroup() {
+    if (!deletingGroup) return;
+    setIsDeletingGroup(true);
+    setStatus(null);
+
+    const { error } = await deleteSkillGroup(deletingGroup.id);
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    } else {
+      setGroups((prev) => prev.filter((g) => g.id !== deletingGroup.id));
+      setStatus({ type: 'success', message: 'Group deleted!' });
+      setIsDeleteDialogOpen(false);
+      setDeletingGroup(null);
+    }
+
+    setIsDeletingGroup(false);
+  }
+
+  async function handleMoveGroup(index: number, direction: 'up' | 'down') {
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    if (targetIndex < 0 || targetIndex >= groups.length) return;
+
+    setIsReorderingGroups(true);
+    setStatus(null);
+
+    const reordered = [...groups];
+    [reordered[index], reordered[targetIndex]] = [reordered[targetIndex], reordered[index]];
+
+    const snapshot = groups;
+    setGroups(reordered);
+
+    const { error } = await reorderSkillGroups(reordered.map((g) => g.id));
+    if (error) {
+      setGroups(snapshot);
+      setStatus({ type: 'error', message: error });
+    }
+
+    setIsReorderingGroups(false);
+  }
+
+  // --- Skill operations ---
+
+  async function handleAddSkill(groupId: string) {
+    const name = newSkillName[groupId]?.trim();
+    if (!name) return;
+
+    setSavingSkillId(groupId);
+    setStatus(null);
+
+    const group = groups.find((g) => g.id === groupId);
+    const { data, error } = await createSkill({
+      name,
+      group_id: groupId,
+      sort_order: group?.skills.length ?? 0,
+    });
+
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    } else if (data) {
+      setGroups((prev) =>
+        prev.map((g) => (g.id === groupId ? { ...g, skills: [...g.skills, data] } : g))
+      );
+      setNewSkillName((prev) => ({ ...prev, [groupId]: '' }));
+    }
+
+    setSavingSkillId(null);
+  }
+
+  function startEditSkill(skill: Skill) {
+    setEditingSkillId(skill.id);
+    setEditingSkillName(skill.name);
+  }
+
+  async function handleSaveSkillEdit(skillId: string) {
+    if (!editingSkillName.trim()) return;
+    setSavingSkillId(skillId);
+
+    const { data, error } = await updateSkill(skillId, { name: editingSkillName.trim() });
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    } else if (data) {
+      setGroups((prev) =>
+        prev.map((g) => ({
+          ...g,
+          skills: g.skills.map((s) => (s.id === data.id ? data : s)),
+        }))
+      );
+      setEditingSkillId(null);
+    }
+
+    setSavingSkillId(null);
+  }
+
+  async function handleDeleteSkill(skillId: string, groupId: string) {
+    setSavingSkillId(skillId);
+    setStatus(null);
+
+    const { error } = await deleteSkill(skillId);
+    if (error) {
+      setStatus({ type: 'error', message: error });
+    } else {
+      setGroups((prev) =>
+        prev.map((g) =>
+          g.id === groupId ? { ...g, skills: g.skills.filter((s) => s.id !== skillId) } : g
+        )
+      );
+    }
+
+    setSavingSkillId(null);
+  }
+
+  async function handleMoveSkill(groupId: string, skillIndex: number, direction: 'up' | 'down') {
+    const group = groups.find((g) => g.id === groupId);
+    if (!group) return;
+
+    const targetIndex = direction === 'up' ? skillIndex - 1 : skillIndex + 1;
+    if (targetIndex < 0 || targetIndex >= group.skills.length) return;
+
+    const reorderedSkills = [...group.skills];
+    [reorderedSkills[skillIndex], reorderedSkills[targetIndex]] = [
+      reorderedSkills[targetIndex],
+      reorderedSkills[skillIndex],
+    ];
+
+    const snapshot = groups;
+    setGroups((prev) =>
+      prev.map((g) => (g.id === groupId ? { ...g, skills: reorderedSkills } : g))
+    );
+
+    const { error } = await reorderSkills(reorderedSkills.map((s) => s.id));
+    if (error) {
+      setGroups(snapshot);
+      setStatus({ type: 'error', message: error });
+    }
+  }
+
+  const isAddGroupMode = editingGroup === null;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Skills Editor</h1>
+          <p className="text-muted-foreground text-sm">Manage skill groups and individual skills</p>
+        </div>
+        <Button onClick={openAddGroupDialog}>
+          <Plus className="mr-1 size-4" />
+          Add Group
+        </Button>
+      </div>
+
+      {status && (
+        <p
+          className={
+            status.type === 'success' ? 'text-sm text-green-600' : 'text-destructive text-sm'
+          }
+        >
+          {status.message}
+        </p>
+      )}
+
+      {groups.length === 0 ? (
+        <p className="text-muted-foreground py-16 text-center text-sm">
+          No skill groups yet. Click &quot;Add Group&quot; to create one.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {groups.map((group, groupIndex) => (
+            <Card key={group.id}>
+              <CardHeader>
+                <div className="flex items-center gap-2">
+                  <div className="flex flex-col gap-0.5">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-6"
+                      onClick={() => handleMoveGroup(groupIndex, 'up')}
+                      disabled={groupIndex === 0 || isReorderingGroups}
+                    >
+                      <ChevronUp className="size-3" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-6"
+                      onClick={() => handleMoveGroup(groupIndex, 'down')}
+                      disabled={groupIndex === groups.length - 1 || isReorderingGroups}
+                    >
+                      <ChevronDown className="size-3" />
+                    </Button>
+                  </div>
+                  <CardTitle className="text-base">{group.category}</CardTitle>
+                </div>
+                <CardAction>
+                  <div className="flex gap-1">
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => openEditGroupDialog(group)}
+                    >
+                      <Pencil className="size-3" />
+                    </Button>
+                    <Button
+                      size="icon"
+                      variant="ghost"
+                      className="size-7"
+                      onClick={() => openDeleteGroupDialog(group)}
+                    >
+                      <Trash2 className="size-3" />
+                    </Button>
+                  </div>
+                </CardAction>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {/* Skill list */}
+                {group.skills.length === 0 && (
+                  <p className="text-muted-foreground py-2 text-center text-xs">
+                    No skills in this group yet.
+                  </p>
+                )}
+                {group.skills.map((skill, skillIndex) => (
+                  <div key={skill.id} className="flex items-center gap-2 rounded-md px-2 py-1.5">
+                    {/* Reorder */}
+                    <div className="flex gap-0.5">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="size-5"
+                        onClick={() => handleMoveSkill(group.id, skillIndex, 'up')}
+                        disabled={skillIndex === 0}
+                      >
+                        <ChevronUp className="size-2.5" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="size-5"
+                        onClick={() => handleMoveSkill(group.id, skillIndex, 'down')}
+                        disabled={skillIndex === group.skills.length - 1}
+                      >
+                        <ChevronDown className="size-2.5" />
+                      </Button>
+                    </div>
+
+                    {/* Skill name — inline edit */}
+                    {editingSkillId === skill.id ? (
+                      <div className="flex flex-1 items-center gap-1">
+                        <Input
+                          value={editingSkillName}
+                          onChange={(e) => setEditingSkillName(e.target.value)}
+                          className="h-7 text-sm"
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleSaveSkillEdit(skill.id);
+                            if (e.key === 'Escape') setEditingSkillId(null);
+                          }}
+                          autoFocus
+                        />
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="size-6"
+                          onClick={() => handleSaveSkillEdit(skill.id)}
+                          disabled={savingSkillId === skill.id}
+                        >
+                          {savingSkillId === skill.id ? (
+                            <Loader2 className="size-3 animate-spin" />
+                          ) : (
+                            <Check className="size-3" />
+                          )}
+                        </Button>
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          className="size-6"
+                          onClick={() => setEditingSkillId(null)}
+                        >
+                          <X className="size-3" />
+                        </Button>
+                      </div>
+                    ) : (
+                      <>
+                        <span className="flex-1 text-sm">{skill.name}</span>
+                        <div className="flex gap-0.5">
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-6"
+                            onClick={() => startEditSkill(skill)}
+                          >
+                            <Pencil className="size-2.5" />
+                          </Button>
+                          <Button
+                            size="icon"
+                            variant="ghost"
+                            className="size-6"
+                            onClick={() => handleDeleteSkill(skill.id, group.id)}
+                            disabled={savingSkillId === skill.id}
+                          >
+                            {savingSkillId === skill.id ? (
+                              <Loader2 className="size-2.5 animate-spin" />
+                            ) : (
+                              <Trash2 className="size-2.5" />
+                            )}
+                          </Button>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                ))}
+
+                {/* Add skill inline */}
+                <div className="flex items-center gap-2 pt-2">
+                  <Input
+                    value={newSkillName[group.id] ?? ''}
+                    onChange={(e) =>
+                      setNewSkillName((prev) => ({ ...prev, [group.id]: e.target.value }))
+                    }
+                    placeholder="New skill name..."
+                    className="h-8 text-sm"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') handleAddSkill(group.id);
+                    }}
+                  />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    onClick={() => handleAddSkill(group.id)}
+                    disabled={savingSkillId === group.id || !newSkillName[group.id]?.trim()}
+                  >
+                    {savingSkillId === group.id ? (
+                      <Loader2 className="size-3 animate-spin" />
+                    ) : (
+                      <Plus className="size-3" />
+                    )}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+
+      {/* Add/Edit Group Dialog */}
+      <Dialog open={isGroupDialogOpen} onOpenChange={setIsGroupDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>{isAddGroupMode ? 'Add Skill Group' : 'Edit Skill Group'}</DialogTitle>
+            <DialogDescription>
+              {isAddGroupMode
+                ? 'Create a new category for grouping skills.'
+                : 'Rename this skill group.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4 py-4">
+            <div className="space-y-2">
+              <Label htmlFor="group-name">Group Name</Label>
+              <Input
+                id="group-name"
+                value={groupName}
+                onChange={(e) => setGroupName(e.target.value)}
+                placeholder="e.g. Frontend, Backend & Database"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleSaveGroup();
+                }}
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsGroupDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSaveGroup} disabled={isSavingGroup || !groupName.trim()}>
+              {isSavingGroup && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isSavingGroup ? 'Saving...' : isAddGroupMode ? 'Create' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Group Dialog */}
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Delete Skill Group</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete &quot;{deletingGroup?.category}&quot;?
+              {deletingGroup && deletingGroup.skills.length > 0 && (
+                <>
+                  {' '}
+                  This will also delete {deletingGroup.skills.length}{' '}
+                  {deletingGroup.skills.length === 1 ? 'skill' : 'skills'} in this group.
+                </>
+              )}{' '}
+              This action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteGroup} disabled={isDeletingGroup}>
+              {isDeletingGroup && <Loader2 className="mr-2 size-4 animate-spin" />}
+              {isDeletingGroup ? 'Deleting...' : 'Delete'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/ui/skeleton.tsx
+++ b/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils';
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-accent animate-pulse rounded-md', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -718,7 +718,17 @@ Installed: `button`, `badge`, `card`, `tooltip` (pre-existing) + `table`, `dialo
 
 - All admin pages and components as needed
 
-### 4H Status: PENDING
+### 4H Implementation Notes
+
+- Installed shadcn/ui `skeleton` component for loading state animations.
+- Created `loading.tsx` skeleton files for all 6 admin pages (dashboard, profile, experience, projects, skills, resume), each mirroring the layout of its corresponding page component.
+- Created `app/admin/(dashboard)/error.tsx` — shared error boundary with AlertTriangle icon, error message, and "Try Again" button. Catches errors within the admin shell so sidebar/header remain visible.
+- Added `--success` CSS custom property to `globals.css` (oklch values for light and dark mode). Replaced all `text-green-600` with `text-success` across 5 admin components.
+- Added required field indicators (`*` asterisks) and client-side validation to profile-form, experience-editor, and projects-editor.
+- Added client-side file validation to resume-manager (PDF type + 10 MB size check before server call).
+- Added 2 new test cases for resume file validation. Updated existing test assertions to use regex patterns for labels with asterisks.
+
+### 4H Status: COMPLETE
 
 ---
 

--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -680,7 +680,16 @@ Installed: `button`, `badge`, `card`, `tooltip` (pre-existing) + `table`, `dialo
 
 - `actions/admin.ts` — add `uploadResume()`, `getResumeDownloads()`
 
-### 4F Status: PENDING
+### 4F Status: COMPLETE
+
+**Implementation notes (4F):**
+
+- Added `getResumeDownloads()` server action — queries `resume_downloads` with visitor join (same pattern as `getAdminStats()`)
+- Added `uploadResume(formData)` server action — accepts FormData, validates PDF type + 10 MB limit, uploads to `resume` bucket with `upsert: true`, updates `profile.resume_url`
+- Consistent filename `resume.pdf` — simplifies replacement via upsert
+- `ResumeManager` client component — current resume card with file info + upload button, download log table with time-ago formatting
+- Server page fetches profile + downloads in parallel via `Promise.all`
+- Cache invalidation uses `revalidatePath('/')` (not `revalidateTag` since Supabase queries don't use `fetch()`)
 
 ---
 

--- a/lib/supabase/setup-admin.ts
+++ b/lib/supabase/setup-admin.ts
@@ -46,10 +46,19 @@ if (!supabaseUrl || !serviceRoleKey) {
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 
 // ---------------------------------------------------------------------------
-// Admin user config
+// Admin user config — read from env vars (ADMIN_EMAIL, ADMIN_PASSWORD)
 // ---------------------------------------------------------------------------
-const ADMIN_EMAIL = 'pateatlau@gmail.com';
-const ADMIN_PASSWORD = 'Tantei@2025';
+const ADMIN_EMAIL = process.env.ADMIN_EMAIL;
+const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD;
+
+if (!ADMIN_EMAIL || !ADMIN_PASSWORD) {
+  console.error(
+    'Missing ADMIN_EMAIL or ADMIN_PASSWORD.\n' +
+      'Set them in .env.local or pass them inline:\n' +
+      '  ADMIN_EMAIL=you@example.com ADMIN_PASSWORD=secret npm run setup-admin'
+  );
+  process.exit(1);
+}
 
 async function main() {
   console.log(`\nSetting up admin user: ${ADMIN_EMAIL}\n`);

--- a/lib/supabase/setup-admin.ts
+++ b/lib/supabase/setup-admin.ts
@@ -1,0 +1,107 @@
+/**
+ * Setup script — creates the first admin user.
+ *
+ * Usage: npm run setup-admin
+ *
+ * Requires NEXT_PUBLIC_SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY in .env.local.
+ * Uses the admin client (service role key) to bypass RLS.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// ---------------------------------------------------------------------------
+// Load env vars from .env.local
+// ---------------------------------------------------------------------------
+function loadEnv() {
+  try {
+    const envPath = resolve(process.cwd(), '.env.local');
+    const content = readFileSync(envPath, 'utf-8');
+    for (const line of content.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const eqIndex = trimmed.indexOf('=');
+      if (eqIndex === -1) continue;
+      const key = trimmed.slice(0, eqIndex).trim();
+      const value = trimmed.slice(eqIndex + 1).trim();
+      if (!process.env[key]) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // .env.local may not exist — that's fine if env vars are set externally
+  }
+}
+loadEnv();
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY in .env.local');
+  process.exit(1);
+}
+
+const supabase = createClient(supabaseUrl, serviceRoleKey);
+
+// ---------------------------------------------------------------------------
+// Admin user config
+// ---------------------------------------------------------------------------
+const ADMIN_EMAIL = 'pateatlau@gmail.com';
+const ADMIN_PASSWORD = 'Tantei@2025';
+
+async function main() {
+  console.log(`\nSetting up admin user: ${ADMIN_EMAIL}\n`);
+
+  // Check if user already exists
+  const { data: existingUsers } = await supabase.auth.admin.listUsers();
+  const existing = existingUsers?.users.find((u) => u.email === ADMIN_EMAIL);
+
+  if (existing) {
+    // User exists — ensure they have admin role
+    const hasAdminRole = existing.app_metadata?.role === 'admin';
+
+    if (hasAdminRole) {
+      console.log('User already exists with admin role. Setting password...');
+    } else {
+      console.log('User exists but missing admin role. Updating...');
+    }
+
+    const { error } = await supabase.auth.admin.updateUserById(existing.id, {
+      password: ADMIN_PASSWORD,
+      app_metadata: { role: 'admin' },
+    });
+
+    if (error) {
+      console.error('Failed to update user:', error.message);
+      process.exit(1);
+    }
+
+    console.log('Admin role and password set successfully.');
+    return;
+  }
+
+  // Create new admin user
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: ADMIN_EMAIL,
+    password: ADMIN_PASSWORD,
+    email_confirm: true,
+    app_metadata: { role: 'admin' },
+  });
+
+  if (error) {
+    console.error('Failed to create admin user:', error.message);
+    process.exit(1);
+  }
+
+  console.log(`Admin user created successfully!`);
+  console.log(`  ID:    ${data.user.id}`);
+  console.log(`  Email: ${data.user.email}`);
+  console.log(`\nYou can now log in at /admin/login`);
+}
+
+main().catch((err) => {
+  console.error('Unexpected error:', err);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
-    "seed": "npx tsx lib/supabase/seed.ts"
+    "seed": "npx tsx lib/supabase/seed.ts",
+    "setup-admin": "npx tsx lib/supabase/setup-admin.ts"
   },
   "dependencies": {
     "@react-email/components": "^1.0.7",


### PR DESCRIPTION
## Summary

- **4B: Profile Editor** — Tabbed form (General/About/Stats) with inline editing and bulk stats management
- **4C: Experience CRUD** — Table view with add/edit/delete dialogs, reorder controls
- **4D: Projects CRUD** — Table with category/tag display, add/edit/delete dialogs, reorder
- **4E: Skills CRUD** — Grouped card view with inline skill editing, keyboard shortcuts (Enter/Escape)
- **4F: Resume Management** — PDF upload to Supabase Storage, download analytics table
- **4H: Polish** — Loading skeletons for all pages, shared error boundary, required field indicators with client-side validation, standardized success color token, client-side file validation
- **Unit Tests** — 182 tests across 8 new test files covering all server actions and admin components

## Test plan

- [x] All 182 unit tests pass (`npx vitest run`)
- [x] Prettier formatting passes (`npm run format:check`)
- [x] ESLint passes (`npm run lint`)
- [x] Production build succeeds (`npm run build`)
- [ ] Manual verification of skeleton loading states and error boundary
- [ ] Manual verification of required field validation in forms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive admin test suites covering auth guards, CRUD/reorder flows, resume upload/download, file validation, and UI interactions.

* **New Features**
  * Admin panel: profile editor (General, About, Stats) with per-tab saves.
  * Editors for experiences, projects, and skills with create/edit/delete/reorder.
  * Resume management: PDF upload (10MB limit), replace, and download history.
  * Loading skeletons and an admin error UI for improved UX.

* **Documentation**
  * Updated admin/CMS plan with implementation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->