### PR TITLE
Add admin E2E tests with Playwright auth setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 
 # testing
 /coverage
+/e2e/.auth/
+/playwright-report/
+/test-results/
 
 # next.js
 /.next/

--- a/e2e/admin-auth.spec.ts
+++ b/e2e/admin-auth.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin Login Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/login');
+  });
+
+  test('renders login form with email and password fields', async ({ page }) => {
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.locator('#password')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign In', exact: true })).toBeVisible();
+  });
+
+  test('displays Admin Dashboard title', async ({ page }) => {
+    await expect(page.getByText('Admin Dashboard')).toBeVisible();
+    await expect(page.getByText('Sign in to manage your portfolio')).toBeVisible();
+  });
+
+  test('has OAuth provider buttons', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Sign in with Google' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign in with GitHub' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Sign in with LinkedIn' })).toBeVisible();
+  });
+
+  test('has back to portfolio link', async ({ page }) => {
+    const backLink = page.getByRole('link', { name: 'Back to portfolio' });
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveAttribute('href', '/');
+  });
+
+  test('email field has correct type and required attribute', async ({ page }) => {
+    await expect(page.locator('#email')).toHaveAttribute('type', 'email');
+    await expect(page.locator('#email')).toHaveAttribute('required', '');
+  });
+
+  test('password field has correct type and required attribute', async ({ page }) => {
+    await expect(page.locator('#password')).toHaveAttribute('type', 'password');
+    await expect(page.locator('#password')).toHaveAttribute('required', '');
+  });
+
+  test('or continue with separator is visible', async ({ page }) => {
+    await expect(page.getByText('Or continue with')).toBeVisible();
+  });
+});
+
+test.describe('Admin Auth Redirect', () => {
+  test('unauthenticated visit to /admin redirects to login', async ({ page }) => {
+    await page.goto('/admin');
+
+    // Should redirect to /admin/login
+    await expect(page).toHaveURL(/\/admin\/login/);
+  });
+});

--- a/e2e/admin-dashboard.spec.ts
+++ b/e2e/admin-dashboard.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+const hasAuth = !!(process.env.E2E_ADMIN_EMAIL && process.env.E2E_ADMIN_PASSWORD);
+
+test.describe('Admin Dashboard', () => {
+  test.skip(!hasAuth, 'Requires E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin');
+  });
+
+  test('dashboard page loads with heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Dashboard', level: 1 })).toBeVisible();
+    await expect(page.getByText('Overview of your portfolio activity')).toBeVisible();
+  });
+
+  test('displays stats cards', async ({ page }) => {
+    await expect(page.getByText('Total Visitors')).toBeVisible();
+    await expect(page.getByText('Total Downloads')).toBeVisible();
+    await expect(page.getByText('Recent Downloads')).toBeVisible();
+  });
+
+  test('displays quick actions section with all links', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Quick Actions' })).toBeVisible();
+
+    const actions = ['Profile', 'Experience', 'Projects', 'Skills', 'Resume', 'Visitors'];
+    for (const action of actions) {
+      await expect(page.getByRole('link', { name: action })).toBeVisible();
+    }
+  });
+
+  test('sidebar navigation is visible with all items', async ({ page }) => {
+    const sidebar = page.locator('aside');
+    await expect(sidebar).toBeVisible();
+
+    const navItems = [
+      'Dashboard',
+      'Profile',
+      'Experience',
+      'Projects',
+      'Skills',
+      'Resume',
+      'Visitors',
+    ];
+    for (const item of navItems) {
+      await expect(sidebar.getByRole('link', { name: item })).toBeVisible();
+    }
+  });
+
+  test('quick action navigates to profile page', async ({ page }) => {
+    await page.getByRole('link', { name: 'Profile' }).first().click();
+    await expect(page).toHaveURL(/\/admin\/profile/);
+    await expect(page.getByRole('heading', { name: 'Profile Editor', level: 1 })).toBeVisible();
+  });
+});

--- a/e2e/admin-experience.spec.ts
+++ b/e2e/admin-experience.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+
+const hasAuth = !!(process.env.E2E_ADMIN_EMAIL && process.env.E2E_ADMIN_PASSWORD);
+
+test.describe('Admin Experience Editor', () => {
+  test.skip(!hasAuth, 'Requires E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/experience');
+  });
+
+  test('experience page loads with heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Experience Editor', level: 1 })).toBeVisible();
+    await expect(page.getByText('Manage your career timeline entries')).toBeVisible();
+  });
+
+  test('add experience button is visible', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Add Experience' })).toBeVisible();
+  });
+
+  test('add dialog opens with form fields', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Experience' }).click();
+
+    // Dialog should open
+    await expect(page.getByRole('heading', { name: 'Add Experience' })).toBeVisible();
+    await expect(page.locator('#exp-title')).toBeVisible();
+    await expect(page.locator('#exp-company')).toBeVisible();
+    await expect(page.locator('#exp-description')).toBeVisible();
+    await expect(page.locator('#exp-display-date')).toBeVisible();
+    await expect(page.locator('#exp-start-date')).toBeVisible();
+  });
+
+  test('add dialog has cancel and create buttons', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Experience' }).click();
+
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create' })).toBeVisible();
+  });
+
+  test('experience table or empty state is visible', async ({ page }) => {
+    // Either a table with experiences or the empty state message
+    const table = page.locator('table');
+    const emptyState = page.getByText('No experiences yet');
+
+    const tableVisible = await table.isVisible().catch(() => false);
+    const emptyVisible = await emptyState.isVisible().catch(() => false);
+
+    expect(tableVisible || emptyVisible).toBe(true);
+  });
+});

--- a/e2e/admin-profile.spec.ts
+++ b/e2e/admin-profile.spec.ts
@@ -1,0 +1,68 @@
+import { test, expect } from '@playwright/test';
+
+const hasAuth = !!(process.env.E2E_ADMIN_EMAIL && process.env.E2E_ADMIN_PASSWORD);
+
+test.describe('Admin Profile Editor', () => {
+  test.skip(!hasAuth, 'Requires E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/profile');
+  });
+
+  test('profile page loads with heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Profile Editor', level: 1 })).toBeVisible();
+    await expect(page.getByText('Edit your personal info, about section, and stats')).toBeVisible();
+  });
+
+  test('three tabs are visible', async ({ page }) => {
+    await expect(page.getByRole('tab', { name: 'General' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'About' })).toBeVisible();
+    await expect(page.getByRole('tab', { name: 'Stats' })).toBeVisible();
+  });
+
+  test('general tab shows form fields', async ({ page }) => {
+    // General tab should be active by default
+    await expect(page.locator('#full_name')).toBeVisible();
+    await expect(page.locator('#short_name')).toBeVisible();
+    await expect(page.locator('#job_title')).toBeVisible();
+    await expect(page.locator('#email')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Save General Info' })).toBeVisible();
+  });
+
+  test('general tab fields have pre-filled values', async ({ page }) => {
+    // Fields should not be empty since profile data exists
+    const fullName = page.locator('#full_name');
+    await expect(fullName).not.toHaveValue('');
+  });
+
+  test('about tab shows textarea fields', async ({ page }) => {
+    await page.getByRole('tab', { name: 'About' }).click();
+
+    await expect(page.locator('#about_tech_stack')).toBeVisible();
+    await expect(page.locator('#about_current_focus')).toBeVisible();
+    await expect(page.locator('#about_beyond_code')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Save About Info' })).toBeVisible();
+  });
+
+  test('stats tab shows stats management', async ({ page }) => {
+    await page.getByRole('tab', { name: 'Stats' }).click();
+
+    await expect(page.getByRole('button', { name: 'Add Stat' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Save Stats' })).toBeVisible();
+  });
+
+  test('tab navigation switches content', async ({ page }) => {
+    // Start on General tab
+    await expect(page.locator('#full_name')).toBeVisible();
+
+    // Switch to About tab
+    await page.getByRole('tab', { name: 'About' }).click();
+    await expect(page.locator('#about_tech_stack')).toBeVisible();
+    await expect(page.locator('#full_name')).not.toBeVisible();
+
+    // Switch to Stats tab
+    await page.getByRole('tab', { name: 'Stats' }).click();
+    await expect(page.getByRole('button', { name: 'Add Stat' })).toBeVisible();
+    await expect(page.locator('#about_tech_stack')).not.toBeVisible();
+  });
+});

--- a/e2e/admin-projects.spec.ts
+++ b/e2e/admin-projects.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test';
+
+const hasAuth = !!(process.env.E2E_ADMIN_EMAIL && process.env.E2E_ADMIN_PASSWORD);
+
+test.describe('Admin Projects Editor', () => {
+  test.skip(!hasAuth, 'Requires E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/projects');
+  });
+
+  test('projects page loads with heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Projects Editor', level: 1 })).toBeVisible();
+    await expect(page.getByText('Manage your portfolio projects')).toBeVisible();
+  });
+
+  test('add project button is visible', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Add Project' })).toBeVisible();
+  });
+
+  test('add dialog opens with form fields', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Project' }).click();
+
+    // Dialog should open
+    await expect(page.getByRole('heading', { name: 'Add Project' })).toBeVisible();
+    await expect(page.locator('#proj-title')).toBeVisible();
+    await expect(page.locator('#proj-description')).toBeVisible();
+    await expect(page.locator('#proj-tags')).toBeVisible();
+  });
+
+  test('add dialog has cancel and create buttons', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Project' }).click();
+
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create' })).toBeVisible();
+  });
+
+  test('projects table or empty state is visible', async ({ page }) => {
+    const table = page.locator('table');
+    const emptyState = page.getByText('No projects yet');
+
+    const tableVisible = await table.isVisible().catch(() => false);
+    const emptyVisible = await emptyState.isVisible().catch(() => false);
+
+    expect(tableVisible || emptyVisible).toBe(true);
+  });
+});

--- a/e2e/admin-resume.spec.ts
+++ b/e2e/admin-resume.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const hasAuth = !!(process.env.E2E_ADMIN_EMAIL && process.env.E2E_ADMIN_PASSWORD);
+
+test.describe('Admin Resume Manager', () => {
+  test.skip(!hasAuth, 'Requires E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/resume');
+  });
+
+  test('resume page loads with heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Resume Management', level: 1 })).toBeVisible();
+    await expect(page.getByText('Upload your resume and view download history')).toBeVisible();
+  });
+
+  test('upload button is visible', async ({ page }) => {
+    // Button text is either "Upload Resume" or "Replace Resume" depending on state
+    const uploadBtn = page.getByRole('button', { name: /Upload Resume|Replace Resume/ });
+    await expect(uploadBtn).toBeVisible();
+  });
+
+  test('file input accepts PDF only', async ({ page }) => {
+    const fileInput = page.locator('input[type="file"]');
+    await expect(fileInput).toHaveAttribute('accept', '.pdf,application/pdf');
+  });
+
+  test('download log section is visible', async ({ page }) => {
+    await expect(page.getByText('Download Log')).toBeVisible();
+
+    // Either a table or the empty state
+    const table = page.locator('table');
+    const emptyState = page.getByText('No downloads recorded yet');
+
+    const tableVisible = await table.isVisible().catch(() => false);
+    const emptyVisible = await emptyState.isVisible().catch(() => false);
+
+    expect(tableVisible || emptyVisible).toBe(true);
+  });
+});

--- a/e2e/admin-skills.spec.ts
+++ b/e2e/admin-skills.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+
+const hasAuth = !!(process.env.E2E_ADMIN_EMAIL && process.env.E2E_ADMIN_PASSWORD);
+
+test.describe('Admin Skills Editor', () => {
+  test.skip(!hasAuth, 'Requires E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD');
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/admin/skills');
+  });
+
+  test('skills page loads with heading', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Skills Editor', level: 1 })).toBeVisible();
+    await expect(page.getByText('Manage skill groups and individual skills')).toBeVisible();
+  });
+
+  test('add group button is visible', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Add Group' })).toBeVisible();
+  });
+
+  test('add group dialog opens with name field', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Group' }).click();
+
+    await expect(page.getByRole('heading', { name: 'Add Skill Group' })).toBeVisible();
+    await expect(page.locator('#group-name')).toBeVisible();
+  });
+
+  test('add group dialog has cancel and create buttons', async ({ page }) => {
+    await page.getByRole('button', { name: 'Add Group' }).click();
+
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Create' })).toBeVisible();
+  });
+
+  test('skill groups or empty state is visible', async ({ page }) => {
+    // Either skill group cards or the empty state message
+    const groupCards = page.locator('[class*="card"]').first();
+    const emptyState = page.getByText('No skill groups yet');
+
+    const cardsVisible = await groupCards.isVisible().catch(() => false);
+    const emptyVisible = await emptyState.isVisible().catch(() => false);
+
+    expect(cardsVisible || emptyVisible).toBe(true);
+  });
+});

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,28 @@
+import { test as setup } from '@playwright/test';
+
+const adminAuthFile = 'e2e/.auth/admin.json';
+
+setup('authenticate as admin', async ({ page }) => {
+  const email = process.env.E2E_ADMIN_EMAIL;
+  const password = process.env.E2E_ADMIN_PASSWORD;
+
+  if (!email || !password) {
+    // Write an empty storage state so the admin project doesn't error
+    await page.context().storageState({ path: adminAuthFile });
+    setup.skip(true, 'E2E_ADMIN_EMAIL / E2E_ADMIN_PASSWORD not set — skipping admin auth setup');
+    return;
+  }
+
+  await page.goto('/admin/login');
+
+  // Fill login form
+  await page.locator('#email').fill(email);
+  await page.locator('#password').fill(password);
+  await page.getByRole('button', { name: 'Sign In', exact: true }).click();
+
+  // Wait for redirect to admin dashboard
+  await page.waitForURL('/admin', { timeout: 15000 });
+
+  // Save auth state
+  await page.context().storageState({ path: adminAuthFile });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const adminAuthFile = 'e2e/.auth/admin.json';
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -12,17 +14,39 @@ export default defineConfig({
     trace: 'on-first-retry',
   },
   projects: [
+    // Public site tests — multi-browser
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      testIgnore: /admin-(?!auth)/,
     },
     {
       name: 'firefox',
       use: { ...devices['Desktop Firefox'] },
+      testIgnore: /admin-(?!auth)/,
     },
     {
       name: 'webkit',
       use: { ...devices['Desktop Safari'] },
+      testIgnore: /admin-(?!auth)/,
+    },
+
+    // Admin auth setup — logs in and saves storageState
+    {
+      name: 'auth-setup',
+      testMatch: /auth\.setup\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    // Authenticated admin tests — Chromium only
+    {
+      name: 'admin',
+      testMatch: /admin-(?!auth).*\.spec\.ts/,
+      dependencies: ['auth-setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: adminAuthFile,
+      },
     },
   ],
   webServer: {


### PR DESCRIPTION
## Summary
- Add 8 Playwright E2E test files covering the entire admin dashboard: auth flow, dashboard, profile editor, experience editor, projects editor, skills editor, and resume manager
- Implement hybrid auth strategy: unauthenticated tests always run; authenticated tests use `storageState` pattern and skip gracefully when `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` env vars are not set
- Update `playwright.config.ts` with `auth-setup` and `admin` projects (Chromium-only for admin, multi-browser preserved for public site)

### Test Files (39 tests + 1 auth setup)
| File | Tests | Auth Required |
|------|-------|---------------|
| `e2e/auth.setup.ts` | 1 | N/A (setup) |
| `e2e/admin-auth.spec.ts` | 8 | No |
| `e2e/admin-dashboard.spec.ts` | 5 | Yes |
| `e2e/admin-profile.spec.ts` | 7 | Yes |
| `e2e/admin-experience.spec.ts` | 5 | Yes |
| `e2e/admin-projects.spec.ts` | 5 | Yes |
| `e2e/admin-skills.spec.ts` | 5 | Yes |
| `e2e/admin-resume.spec.ts` | 4 | Yes |

## Test plan
- [x] All 8 unauthenticated admin-auth tests pass locally
- [x] All 36 Chromium tests pass (admin-auth + existing public site)
- [x] Authenticated admin tests skip gracefully without env vars
- [ ] CI pipeline passes (lint, build, E2E)
- [ ] With `E2E_ADMIN_EMAIL`/`E2E_ADMIN_PASSWORD` set, authenticated tests pass against real Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite for admin features including login authentication, dashboard navigation, and management tools for profile, projects, experience, skills, and resume functionality.
  * Implemented authenticated testing environment setup with credential-based access.

* **Chores**
  * Updated test configuration and gitignore to exclude test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->