### PR TITLE
Add admin Visitors page (Phase 4G)

### DIFF
--- a/__tests__/components/admin/visitors-table.test.tsx
+++ b/__tests__/components/admin/visitors-table.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import VisitorsTable from '@/components/admin/visitors-table';
+import { mockVisitors } from '../../helpers/admin-fixtures';
+
+vi.mock('@/actions/admin', () => ({
+  getVisitorsCsvData: vi.fn(),
+}));
+
+import { getVisitorsCsvData } from '@/actions/admin';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('VisitorsTable', () => {
+  it('renders heading and total count', () => {
+    render(<VisitorsTable visitors={mockVisitors} />);
+    expect(screen.getByRole('heading', { name: 'Visitors' })).toBeInTheDocument();
+    expect(screen.getByText(/3 total visitors/)).toBeInTheDocument();
+  });
+
+  it('renders visitor names and emails in the table', () => {
+    render(<VisitorsTable visitors={mockVisitors} />);
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Johnson')).toBeInTheDocument();
+    expect(screen.getByText('jane@example.com')).toBeInTheDocument();
+    expect(screen.getByText('bob@example.com')).toBeInTheDocument();
+  });
+
+  it('shows em dash for null visitor name', () => {
+    render(<VisitorsTable visitors={mockVisitors} />);
+    // The third visitor has null fullName — look for em dashes in name cells
+    const rows = screen.getAllByRole('row');
+    // Header + 3 data rows
+    expect(rows.length).toBe(4);
+  });
+
+  it('renders provider badges', () => {
+    render(<VisitorsTable visitors={mockVisitors} />);
+    expect(screen.getAllByText('Google').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('GitHub')).toBeInTheDocument();
+  });
+
+  it('displays download counts', () => {
+    render(<VisitorsTable visitors={mockVisitors} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('0')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no visitors', () => {
+    render(<VisitorsTable visitors={[]} />);
+    expect(screen.getByText('No visitors yet.')).toBeInTheDocument();
+    expect(screen.getByText('0 total visitors')).toBeInTheDocument();
+  });
+
+  it('filters visitors by search query', async () => {
+    const user = userEvent.setup();
+    render(<VisitorsTable visitors={mockVisitors} />);
+
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    await user.type(searchInput, 'Jane');
+
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Johnson')).not.toBeInTheDocument();
+  });
+
+  it('filters visitors by provider when only one provider exists', () => {
+    // Test provider filtering by rendering visitors with a single provider
+    const githubOnly = mockVisitors.filter((v) => v.provider === 'github');
+    render(<VisitorsTable visitors={githubOnly} />);
+
+    expect(screen.getByText('Bob Johnson')).toBeInTheDocument();
+    expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument();
+    expect(screen.getByText('1 total visitor')).toBeInTheDocument();
+  });
+
+  it('shows no-match state when filters exclude all visitors', async () => {
+    const user = userEvent.setup();
+    render(<VisitorsTable visitors={mockVisitors} />);
+
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    await user.type(searchInput, 'nonexistentperson');
+
+    expect(screen.getByText('No visitors match your filters.')).toBeInTheDocument();
+  });
+
+  it('sorts visitors by name when clicking name header', async () => {
+    const user = userEvent.setup();
+    // Use visitors that all have names so sort order is deterministic
+    const namedVisitors = mockVisitors.filter((v) => v.fullName !== null);
+    render(<VisitorsTable visitors={namedVisitors} />);
+
+    const nameButton = screen.getByRole('button', { name: /name/i });
+    await user.click(nameButton);
+
+    // After sorting by name ascending, first data row should be Bob (B < J)
+    const rows = screen.getAllByRole('row');
+    const firstDataRow = rows[1];
+    expect(within(firstDataRow).getByText('Bob Johnson')).toBeInTheDocument();
+  });
+
+  it('triggers CSV export on button click', async () => {
+    const user = userEvent.setup();
+    vi.mocked(getVisitorsCsvData).mockResolvedValue({
+      data: 'Name,Email\nJane,jane@test.com',
+    });
+
+    // Mock URL.createObjectURL and URL.revokeObjectURL
+    const createObjectURL = vi.fn().mockReturnValue('blob:test');
+    const revokeObjectURL = vi.fn();
+    global.URL.createObjectURL = createObjectURL;
+    global.URL.revokeObjectURL = revokeObjectURL;
+
+    render(<VisitorsTable visitors={mockVisitors} />);
+
+    const exportBtn = screen.getByRole('button', { name: /export csv/i });
+    await user.click(exportBtn);
+
+    expect(getVisitorsCsvData).toHaveBeenCalledTimes(1);
+    expect(createObjectURL).toHaveBeenCalled();
+    expect(revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('renders Export CSV button', () => {
+    render(<VisitorsTable visitors={mockVisitors} />);
+    expect(screen.getByRole('button', { name: /export csv/i })).toBeInTheDocument();
+  });
+
+  it('searches by company', async () => {
+    const user = userEvent.setup();
+    render(<VisitorsTable visitors={mockVisitors} />);
+
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    await user.type(searchInput, 'TechCo');
+
+    expect(screen.getByText('Jane Smith')).toBeInTheDocument();
+    expect(screen.queryByText('Bob Johnson')).not.toBeInTheDocument();
+  });
+
+  it('searches by role', async () => {
+    const user = userEvent.setup();
+    render(<VisitorsTable visitors={mockVisitors} />);
+
+    const searchInput = screen.getByPlaceholderText(/search/i);
+    await user.type(searchInput, 'CTO');
+
+    // v-3 has role "CTO"
+    expect(screen.getByText('anonymous@example.com')).toBeInTheDocument();
+    expect(screen.queryByText('Jane Smith')).not.toBeInTheDocument();
+  });
+});

--- a/__tests__/components/admin/visitors-table.test.tsx
+++ b/__tests__/components/admin/visitors-table.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import VisitorsTable from '@/components/admin/visitors-table';
@@ -10,8 +10,16 @@ vi.mock('@/actions/admin', () => ({
 
 import { getVisitorsCsvData } from '@/actions/admin';
 
+const originalCreateObjectURL = global.URL.createObjectURL;
+const originalRevokeObjectURL = global.URL.revokeObjectURL;
+
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+afterEach(() => {
+  global.URL.createObjectURL = originalCreateObjectURL;
+  global.URL.revokeObjectURL = originalRevokeObjectURL;
 });
 
 describe('VisitorsTable', () => {
@@ -31,10 +39,13 @@ describe('VisitorsTable', () => {
 
   it('shows em dash for null visitor name', () => {
     render(<VisitorsTable visitors={mockVisitors} />);
-    // The third visitor has null fullName — look for em dashes in name cells
     const rows = screen.getAllByRole('row');
-    // Header + 3 data rows
+    // Header + 3 data rows (default sort is joined desc, so v-3 with null name is first)
     expect(rows.length).toBe(4);
+    // v-3 has null fullName — its name cell should render an em dash
+    const firstDataRow = rows[1];
+    const nameCell = within(firstDataRow).getAllByRole('cell')[0];
+    expect(nameCell).toHaveTextContent('—');
   });
 
   it('renders provider badges', () => {

--- a/__tests__/helpers/admin-fixtures.ts
+++ b/__tests__/helpers/admin-fixtures.ts
@@ -6,7 +6,7 @@ import type {
   ProjectCategory,
   SkillGroupWithSkills,
 } from '@/lib/supabase/types';
-import type { ResumeDownloadEntry } from '@/actions/admin';
+import type { ResumeDownloadEntry, VisitorEntry } from '@/actions/admin';
 
 export const mockProfile: Profile = {
   id: 'profile-1',
@@ -126,5 +126,41 @@ export const mockDownloads: ResumeDownloadEntry[] = [
     visitorName: null,
     visitorEmail: null,
     visitorCompany: null,
+  },
+];
+
+export const mockVisitors: VisitorEntry[] = [
+  {
+    id: 'v-1',
+    fullName: 'Jane Smith',
+    email: 'jane@example.com',
+    avatarUrl: 'https://example.com/jane.jpg',
+    provider: 'google',
+    company: 'TechCo',
+    role: 'Engineer',
+    createdAt: new Date(Date.now() - 86400000).toISOString(),
+    downloadCount: 3,
+  },
+  {
+    id: 'v-2',
+    fullName: 'Bob Johnson',
+    email: 'bob@example.com',
+    avatarUrl: null,
+    provider: 'github',
+    company: null,
+    role: null,
+    createdAt: new Date(Date.now() - 172800000).toISOString(),
+    downloadCount: 0,
+  },
+  {
+    id: 'v-3',
+    fullName: null,
+    email: 'anonymous@example.com',
+    avatarUrl: null,
+    provider: 'google',
+    company: 'StartupXYZ',
+    role: 'CTO',
+    createdAt: new Date(Date.now() - 3600000).toISOString(),
+    downloadCount: 1,
   },
 ];

--- a/actions/admin.ts
+++ b/actions/admin.ts
@@ -782,7 +782,7 @@ export async function getVisitorsCsvData(): Promise<{
 }
 
 function escapeCsvField(value: string): string {
-  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
     return `"${value.replace(/"/g, '""')}"`;
   }
   return value;

--- a/actions/admin.ts
+++ b/actions/admin.ts
@@ -685,3 +685,105 @@ export async function uploadResume(
   revalidatePath('/');
   return { data: { path: storagePath } };
 }
+
+// --- Visitor Management Actions ---
+
+export type VisitorEntry = {
+  id: string;
+  fullName: string | null;
+  email: string | null;
+  avatarUrl: string | null;
+  provider: string | null;
+  company: string | null;
+  role: string | null;
+  createdAt: string;
+  downloadCount: number;
+};
+
+export async function getVisitors(): Promise<{
+  data?: VisitorEntry[];
+  error?: string;
+}> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const supabase = await createClient();
+
+  const { data: visitors, error } = await supabase
+    .from('visitor_profiles')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('getVisitors error:', error.message);
+    return { error: 'Failed to load visitors' };
+  }
+
+  if (!visitors || visitors.length === 0) {
+    return { data: [] };
+  }
+
+  // Fetch download counts per visitor
+  const visitorIds = visitors.map((v) => v.id);
+  const { data: downloads } = await supabase
+    .from('resume_downloads')
+    .select('visitor_id')
+    .in('visitor_id', visitorIds);
+
+  const downloadCounts = new Map<string, number>();
+  if (downloads) {
+    for (const dl of downloads) {
+      if (dl.visitor_id) {
+        downloadCounts.set(dl.visitor_id, (downloadCounts.get(dl.visitor_id) ?? 0) + 1);
+      }
+    }
+  }
+
+  return {
+    data: visitors.map((v) => ({
+      id: v.id,
+      fullName: v.full_name,
+      email: v.email,
+      avatarUrl: v.avatar_url,
+      provider: v.provider,
+      company: v.company,
+      role: v.role,
+      createdAt: v.created_at,
+      downloadCount: downloadCounts.get(v.id) ?? 0,
+    })),
+  };
+}
+
+export async function getVisitorsCsvData(): Promise<{
+  data?: string;
+  error?: string;
+}> {
+  const adminResult = await requireAdmin();
+  if (adminResult.error) return { error: adminResult.error };
+
+  const visitorsResult = await getVisitors();
+  if (visitorsResult.error) return { error: visitorsResult.error };
+
+  const visitors = visitorsResult.data ?? [];
+
+  const headers = ['Name', 'Email', 'Provider', 'Company', 'Role', 'Downloads', 'Joined'];
+  const rows = visitors.map((v) => [
+    escapeCsvField(v.fullName ?? ''),
+    escapeCsvField(v.email ?? ''),
+    escapeCsvField(v.provider ?? ''),
+    escapeCsvField(v.company ?? ''),
+    escapeCsvField(v.role ?? ''),
+    String(v.downloadCount),
+    v.createdAt ? new Date(v.createdAt).toISOString().split('T')[0] : '',
+  ]);
+
+  const csv = [headers.join(','), ...rows.map((r) => r.join(','))].join('\n');
+  return { data: csv };
+}
+
+function escapeCsvField(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}

--- a/app/admin/(dashboard)/visitors/loading.tsx
+++ b/app/admin/(dashboard)/visitors/loading.tsx
@@ -1,0 +1,30 @@
+import { Skeleton } from '@/components/ui/skeleton';
+
+export default function VisitorsLoading() {
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <Skeleton className="h-8 w-32" />
+          <Skeleton className="mt-2 h-4 w-40" />
+        </div>
+        <Skeleton className="h-9 w-28" />
+      </div>
+
+      {/* Filters */}
+      <div className="flex gap-3">
+        <Skeleton className="h-10 flex-1" />
+        <Skeleton className="h-10 w-[160px]" />
+      </div>
+
+      {/* Table rows */}
+      <div className="space-y-3">
+        <Skeleton className="h-10 w-full" />
+        {Array.from({ length: 8 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/admin/(dashboard)/visitors/page.tsx
+++ b/app/admin/(dashboard)/visitors/page.tsx
@@ -1,0 +1,16 @@
+import { getVisitors } from '@/actions/admin';
+import VisitorsTable from '@/components/admin/visitors-table';
+
+export default async function VisitorsPage() {
+  const result = await getVisitors();
+
+  if (result.error) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-muted-foreground">Failed to load visitors.</p>
+      </div>
+    );
+  }
+
+  return <VisitorsTable visitors={result.data ?? []} />;
+}

--- a/components/admin/visitors-table.tsx
+++ b/components/admin/visitors-table.tsx
@@ -1,0 +1,312 @@
+'use client';
+
+import React, { useMemo, useState } from 'react';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Download, Search, ArrowUpDown, Users } from 'lucide-react';
+import { getVisitorsCsvData } from '@/actions/admin';
+import type { VisitorEntry } from '@/actions/admin';
+
+type SortField = 'name' | 'email' | 'provider' | 'downloads' | 'joined';
+type SortDirection = 'asc' | 'desc';
+
+const ITEMS_PER_PAGE = 20;
+
+function timeAgo(dateStr: string): string {
+  const seconds = Math.floor((Date.now() - new Date(dateStr).getTime()) / 1000);
+  if (seconds < 60) return 'just now';
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  const months = Math.floor(days / 30);
+  return `${months}mo ago`;
+}
+
+function providerLabel(provider: string | null): string {
+  if (!provider) return 'Unknown';
+  const labels: Record<string, string> = {
+    google: 'Google',
+    github: 'GitHub',
+    linkedin_oidc: 'LinkedIn',
+    email: 'Email',
+  };
+  return labels[provider] ?? provider;
+}
+
+export default function VisitorsTable({ visitors }: { visitors: VisitorEntry[] }) {
+  const [search, setSearch] = useState('');
+  const [providerFilter, setProviderFilter] = useState<string>('all');
+  const [sortField, setSortField] = useState<SortField>('joined');
+  const [sortDir, setSortDir] = useState<SortDirection>('desc');
+  const [page, setPage] = useState(0);
+  const [isExporting, setIsExporting] = useState(false);
+
+  // Unique providers for filter dropdown
+  const providers = useMemo(() => {
+    const set = new Set(visitors.map((v) => v.provider).filter(Boolean) as string[]);
+    return Array.from(set).sort();
+  }, [visitors]);
+
+  // Filter + search
+  const filtered = useMemo(() => {
+    const q = search.toLowerCase().trim();
+    return visitors.filter((v) => {
+      if (providerFilter !== 'all' && v.provider !== providerFilter) return false;
+      if (!q) return true;
+      return (
+        v.fullName?.toLowerCase().includes(q) ||
+        v.email?.toLowerCase().includes(q) ||
+        v.company?.toLowerCase().includes(q) ||
+        v.role?.toLowerCase().includes(q)
+      );
+    });
+  }, [visitors, search, providerFilter]);
+
+  // Sort
+  const sorted = useMemo(() => {
+    const arr = [...filtered];
+    const dir = sortDir === 'asc' ? 1 : -1;
+
+    arr.sort((a, b) => {
+      switch (sortField) {
+        case 'name':
+          return (a.fullName ?? '').localeCompare(b.fullName ?? '') * dir;
+        case 'email':
+          return (a.email ?? '').localeCompare(b.email ?? '') * dir;
+        case 'provider':
+          return (a.provider ?? '').localeCompare(b.provider ?? '') * dir;
+        case 'downloads':
+          return (a.downloadCount - b.downloadCount) * dir;
+        case 'joined':
+          return (new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()) * dir;
+        default:
+          return 0;
+      }
+    });
+
+    return arr;
+  }, [filtered, sortField, sortDir]);
+
+  // Paginate
+  const totalPages = Math.max(1, Math.ceil(sorted.length / ITEMS_PER_PAGE));
+  const paginated = sorted.slice(page * ITEMS_PER_PAGE, (page + 1) * ITEMS_PER_PAGE);
+
+  // Reset page when filters change
+  const handleSearch = (value: string) => {
+    setSearch(value);
+    setPage(0);
+  };
+
+  const handleProviderFilter = (value: string) => {
+    setProviderFilter(value);
+    setPage(0);
+  };
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortField(field);
+      setSortDir('asc');
+    }
+    setPage(0);
+  };
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const result = await getVisitorsCsvData();
+      if (result.error || !result.data) return;
+
+      const blob = new Blob([result.data], { type: 'text/csv;charset=utf-8;' });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `visitors-${new Date().toISOString().split('T')[0]}.csv`;
+      link.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  const SortButton = ({ field, children }: { field: SortField; children: React.ReactNode }) => (
+    <button
+      type="button"
+      className="hover:text-foreground inline-flex items-center gap-1"
+      onClick={() => handleSort(field)}
+    >
+      {children}
+      <ArrowUpDown
+        className={`size-3 ${sortField === field ? 'text-foreground' : 'text-muted-foreground/50'}`}
+      />
+    </button>
+  );
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Visitors</h1>
+          <p className="text-muted-foreground text-sm">
+            {visitors.length} total visitor{visitors.length !== 1 ? 's' : ''}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={handleExport} disabled={isExporting}>
+          <Download className="mr-2 size-4" />
+          {isExporting ? 'Exporting...' : 'Export CSV'}
+        </Button>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <div className="relative flex-1">
+          <Search className="text-muted-foreground absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+          <Input
+            placeholder="Search by name, email, company, or role..."
+            value={search}
+            onChange={(e) => handleSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+        <Select value={providerFilter} onValueChange={handleProviderFilter}>
+          <SelectTrigger className="w-full sm:w-[160px]">
+            <SelectValue placeholder="All providers" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All providers</SelectItem>
+            {providers.map((p) => (
+              <SelectItem key={p} value={p}>
+                {providerLabel(p)}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* Table */}
+      {sorted.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16">
+          <Users className="text-muted-foreground/50 mb-4 size-12" />
+          <p className="text-muted-foreground text-sm">
+            {visitors.length === 0 ? 'No visitors yet.' : 'No visitors match your filters.'}
+          </p>
+        </div>
+      ) : (
+        <>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>
+                  <SortButton field="name">Name</SortButton>
+                </TableHead>
+                <TableHead className="hidden sm:table-cell">
+                  <SortButton field="email">Email</SortButton>
+                </TableHead>
+                <TableHead className="hidden md:table-cell">
+                  <SortButton field="provider">Provider</SortButton>
+                </TableHead>
+                <TableHead className="hidden lg:table-cell">Company</TableHead>
+                <TableHead className="hidden lg:table-cell">Role</TableHead>
+                <TableHead className="w-[100px]">
+                  <SortButton field="downloads">Downloads</SortButton>
+                </TableHead>
+                <TableHead className="w-[100px]">
+                  <SortButton field="joined">Joined</SortButton>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {paginated.map((v) => (
+                <TableRow key={v.id}>
+                  <TableCell>
+                    <div className="flex items-center gap-2">
+                      <Avatar className="size-7">
+                        {v.avatarUrl ? (
+                          <AvatarImage src={v.avatarUrl} alt={v.fullName ?? ''} />
+                        ) : null}
+                        <AvatarFallback className="text-xs">
+                          {(v.fullName ?? '?').charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+                      <span className="font-medium">{v.fullName ?? '—'}</span>
+                    </div>
+                  </TableCell>
+                  <TableCell className="text-muted-foreground hidden sm:table-cell">
+                    {v.email ?? '—'}
+                  </TableCell>
+                  <TableCell className="hidden md:table-cell">
+                    {v.provider ? (
+                      <Badge variant="secondary">{providerLabel(v.provider)}</Badge>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground hidden lg:table-cell">
+                    {v.company ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground hidden lg:table-cell">
+                    {v.role ?? '—'}
+                  </TableCell>
+                  <TableCell className="text-center">{v.downloadCount}</TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {timeAgo(v.createdAt)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between">
+              <p className="text-muted-foreground text-sm">
+                Showing {page * ITEMS_PER_PAGE + 1}–
+                {Math.min((page + 1) * ITEMS_PER_PAGE, sorted.length)} of {sorted.length}
+              </p>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => p - 1)}
+                  disabled={page === 0}
+                >
+                  Previous
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={page >= totalPages - 1}
+                >
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/components/admin/visitors-table.tsx
+++ b/components/admin/visitors-table.tsx
@@ -60,6 +60,7 @@ export default function VisitorsTable({ visitors }: { visitors: VisitorEntry[] }
   const [sortDir, setSortDir] = useState<SortDirection>('desc');
   const [page, setPage] = useState(0);
   const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
 
   // Unique providers for filter dropdown
   const providers = useMemo(() => {
@@ -134,9 +135,13 @@ export default function VisitorsTable({ visitors }: { visitors: VisitorEntry[] }
 
   const handleExport = async () => {
     setIsExporting(true);
+    setExportError(null);
     try {
       const result = await getVisitorsCsvData();
-      if (result.error || !result.data) return;
+      if (result.error || !result.data) {
+        setExportError(result.error ?? 'Failed to export visitors');
+        return;
+      }
 
       const blob = new Blob([result.data], { type: 'text/csv;charset=utf-8;' });
       const url = URL.createObjectURL(blob);
@@ -145,6 +150,8 @@ export default function VisitorsTable({ visitors }: { visitors: VisitorEntry[] }
       link.download = `visitors-${new Date().toISOString().split('T')[0]}.csv`;
       link.click();
       URL.revokeObjectURL(url);
+    } catch {
+      setExportError('An unexpected error occurred during export');
     } finally {
       setIsExporting(false);
     }
@@ -178,6 +185,8 @@ export default function VisitorsTable({ visitors }: { visitors: VisitorEntry[] }
           {isExporting ? 'Exporting...' : 'Export CSV'}
         </Button>
       </div>
+
+      {exportError && <p className="text-destructive text-sm">{exportError}</p>}
 
       {/* Filters */}
       <div className="flex flex-col gap-3 sm:flex-row">

--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -706,7 +706,27 @@ Installed: `button`, `badge`, `card`, `tooltip` (pre-existing) + `table`, `dialo
 
 - `actions/admin.ts` — add `getVisitors()`, `getVisitorsCsvData()`
 
-### 4G Status: PENDING
+### 4G Implementation Notes
+
+- Created `app/admin/(dashboard)/visitors/page.tsx` — server component that fetches visitors via `getVisitors()` and passes `VisitorEntry[]` to `VisitorsTable` client component. Handles error with fallback UI.
+- Created `components/admin/visitors-table.tsx` — client component with:
+  - **Table view**: Columns for Name (with avatar), Email, Provider (Badge), Company, Role, Downloads (count), Joined (time-ago). Responsive: Email hidden on mobile, Provider hidden below md, Company/Role hidden below lg.
+  - **Search**: Full-text search across name, email, company, and role fields. Resets pagination on change.
+  - **Provider filter**: Select dropdown with dynamically populated providers (Google, GitHub, LinkedIn, etc.) plus "All providers" option.
+  - **Sortable columns**: Name, Email, Provider, Downloads, Joined — click toggles asc/desc with visual indicator via ArrowUpDown icon.
+  - **Pagination**: 20 items per page with Previous/Next buttons and "Showing X–Y of Z" indicator.
+  - **CSV export**: "Export CSV" button calls `getVisitorsCsvData()` server action, generates a Blob, and triggers browser download with date-stamped filename.
+  - **Empty states**: Distinct messages for "No visitors yet" vs "No visitors match your filters."
+- Added 2 server actions to `actions/admin.ts`:
+  - `getVisitors()` — fetches all `visitor_profiles` ordered by `created_at` desc, joins download counts from `resume_downloads` via a second query + Map aggregation. Returns camelCase `VisitorEntry[]`.
+  - `getVisitorsCsvData()` — calls `getVisitors()` internally, formats as CSV string with proper field escaping (commas, quotes, newlines).
+- Added `VisitorEntry` exported type for use in component props and test fixtures.
+- Created `app/admin/(dashboard)/visitors/loading.tsx` — skeleton loading state matching the visitors page layout.
+- Added `mockVisitors` fixture to `__tests__/helpers/admin-fixtures.ts` (3 visitors: Google, GitHub, null-name).
+- Added 10 server action tests (getVisitors: 5, getVisitorsCsvData: 4 including CSV escaping) and 14 component tests (rendering, search, sort, export, empty states).
+- All actions follow the established pattern: `requireAdmin()` → DB query → return `{ data?, error? }`.
+
+### 4G Status: COMPLETE
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds the **Visitors** management page (`/admin/visitors`) — the final Phase 4 sub-task
- New server actions: `getVisitors()` (fetches visitor profiles with download counts) and `getVisitorsCsvData()` (CSV export with proper field escaping)
- Responsive table with avatar, provider badges, sortable columns (name, email, provider, downloads, joined), full-text search, provider filter dropdown, and pagination (20/page)
- Loading skeleton and empty states (no visitors vs. no matches)
- 24 new unit tests (10 server action + 14 component), bringing total to **205 passing tests**

## Test plan
- [ ] `npm run test` — all 205 tests pass
- [ ] `npm run lint` — no warnings
- [ ] `npm run build` — production build succeeds with `/admin/visitors` route
- [ ] `npm run format:check` — Prettier formatting clean
- [ ] Manual: navigate to `/admin/visitors`, verify table renders, search filters, sort toggles, pagination works, CSV export downloads file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visitors admin page with searchable, filterable, sortable table, pagination, and loading skeleton
  * CSV export/download of visitor data
  * Provider-based filtering, multi-field sorting, and per-visitor download counts

* **Tests**
  * Comprehensive server and UI tests covering data fetching, CSV generation/export, filtering, sorting, and empty states

* **Documentation**
  * Updated plan documenting the Visitors page, server actions, and UI behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->