### PR TITLE
Skip proxy session refresh on /auth/callback to preserve PKCE verifier

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -12,7 +12,7 @@ export async function proxy(request: NextRequest) {
   // Skip session refresh on the auth callback route — getUser() with no
   // session removes the PKCE code verifier cookie, which the callback route
   // handler needs to exchange the auth code for a session.
-  if (request.nextUrl.pathname === '/auth/callback') {
+  if (request.nextUrl.pathname.startsWith('/auth/callback')) {
     return supabaseResponse;
   }
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,6 +9,13 @@ export async function proxy(request: NextRequest) {
     return supabaseResponse;
   }
 
+  // Skip session refresh on the auth callback route — getUser() with no
+  // session removes the PKCE code verifier cookie, which the callback route
+  // handler needs to exchange the auth code for a session.
+  if (request.nextUrl.pathname === '/auth/callback') {
+    return supabaseResponse;
+  }
+
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,


### PR DESCRIPTION
The proxy calls getUser() on every request to refresh the auth session. When there is no session (as during OAuth callback), getUser() throws AuthSessionMissingError which internally removes the PKCE code verifier cookie. The callback route handler then fails to exchange the auth code because the verifier is gone.

Fix: skip the proxy entirely for /auth/callback — the callback route handles its own Supabase client and cookie management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication callback handling: the callback path now avoids extra backend operations, reducing delays and preventing intermittent failures during sign-in so OAuth-based logins complete more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->