### PR TITLE
Add testing & CI/CD updates (Phase 6)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,13 @@ NEXT_TELEMETRY_DISABLED=1
 # Vercel OIDC
 VERCEL_OIDC_TOKEN=eyJ...
 
-# Supabase
+# Supabase (CMS backend)
+# Required for full functionality. Without these, the app falls back to
+# static data from lib/data.ts and logs a warning.
 NEXT_PUBLIC_SUPABASE_URL=https://xxx.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=eyJ...
 SUPABASE_SERVICE_ROLE_KEY=eyJ...
+
+# E2E testing (optional — admin E2E tests skip without these)
+# E2E_ADMIN_EMAIL=admin@example.com
+# E2E_ADMIN_PASSWORD=xxx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Note: Supabase secrets (NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY)
+# are required for full CI. Fork contributors without these secrets will see a
+# warning and the build will use the static data fallback from lib/data.ts.
 env:
   NODE_VERSION: '20'
 
@@ -85,6 +88,11 @@ jobs:
 
       - name: Run E2E tests
         run: npm run test:e2e -- --project=chromium
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          E2E_ADMIN_EMAIL: ${{ secrets.E2E_ADMIN_EMAIL }}
+          E2E_ADMIN_PASSWORD: ${{ secrets.E2E_ADMIN_PASSWORD }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
@@ -111,10 +119,18 @@ jobs:
       - name: Install dependencies
         run: npm install --legacy-peer-deps
 
+      - name: Validate Supabase connection
+        run: npm run validate-supabase
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
       - name: Build application
         run: npm run build
         env:
           RESEND_API_KEY: ${{ secrets.RESEND_API_KEY }}
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/__tests__/components/auth/login-modal.test.tsx
+++ b/__tests__/components/auth/login-modal.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import LoginModal from '@/components/auth/login-modal';
+
+// Mock the auth context
+const mockSignInWithProvider = vi.fn();
+
+vi.mock('@/context/auth-context', () => ({
+  useAuth: () => ({
+    signInWithProvider: mockSignInWithProvider,
+  }),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+});
+
+describe('LoginModal', () => {
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(<LoginModal isOpen={false} onClose={vi.fn()} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders heading and social login buttons when open', () => {
+    render(<LoginModal isOpen={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Sign in to download')).toBeInTheDocument();
+    expect(screen.getByText('Continue with Google')).toBeInTheDocument();
+    expect(screen.getByText('Continue with GitHub')).toBeInTheDocument();
+    expect(screen.getByText('Continue with LinkedIn')).toBeInTheDocument();
+  });
+
+  it('renders Cancel button', () => {
+    render(<LoginModal isOpen={true} onClose={vi.fn()} />);
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(<LoginModal isOpen={true} onClose={onClose} />);
+
+    await user.click(screen.getByText('Cancel'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when backdrop is clicked', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    const { container } = render(<LoginModal isOpen={true} onClose={onClose} />);
+
+    // The backdrop is the first child div (fixed inset-0)
+    const backdrop = container.querySelector('[class*="fixed inset-0"]');
+    expect(backdrop).not.toBeNull();
+    await user.click(backdrop!);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls signInWithProvider with "google" when Google button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<LoginModal isOpen={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByText('Continue with Google'));
+    expect(mockSignInWithProvider).toHaveBeenCalledWith('google');
+  });
+
+  it('calls signInWithProvider with "github" when GitHub button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<LoginModal isOpen={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByText('Continue with GitHub'));
+    expect(mockSignInWithProvider).toHaveBeenCalledWith('github');
+  });
+
+  it('calls signInWithProvider with "linkedin_oidc" when LinkedIn button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<LoginModal isOpen={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByText('Continue with LinkedIn'));
+    expect(mockSignInWithProvider).toHaveBeenCalledWith('linkedin_oidc');
+  });
+
+  it('stores pendingAction in localStorage on login', async () => {
+    const user = userEvent.setup();
+    render(<LoginModal isOpen={true} onClose={vi.fn()} />);
+
+    await user.click(screen.getByText('Continue with Google'));
+    expect(localStorage.setItem).toHaveBeenCalledWith('pendingAction', 'download_resume');
+  });
+});

--- a/__tests__/components/auth/login-modal.test.tsx
+++ b/__tests__/components/auth/login-modal.test.tsx
@@ -49,12 +49,10 @@ describe('LoginModal', () => {
   it('calls onClose when backdrop is clicked', async () => {
     const user = userEvent.setup();
     const onClose = vi.fn();
-    const { container } = render(<LoginModal isOpen={true} onClose={onClose} />);
+    render(<LoginModal isOpen={true} onClose={onClose} />);
 
-    // The backdrop is the first child div (fixed inset-0)
-    const backdrop = container.querySelector('[class*="fixed inset-0"]');
-    expect(backdrop).not.toBeNull();
-    await user.click(backdrop!);
+    const backdrop = screen.getByTestId('backdrop');
+    await user.click(backdrop);
     expect(onClose).toHaveBeenCalledOnce();
   });
 

--- a/__tests__/components/auth/optional-fields-modal.test.tsx
+++ b/__tests__/components/auth/optional-fields-modal.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../test-utils';
+import userEvent from '@testing-library/user-event';
+import OptionalFieldsModal from '@/components/auth/optional-fields-modal';
+
+// Mock the server action
+const mockUpdateVisitorOptionalFields = vi.fn();
+
+vi.mock('@/actions/resume', () => ({
+  updateVisitorOptionalFields: (...args: unknown[]) => mockUpdateVisitorOptionalFields(...args),
+}));
+
+// Mock react-hot-toast
+const mockToastError = vi.fn();
+vi.mock('react-hot-toast', () => ({
+  default: {
+    error: (...args: unknown[]) => mockToastError(...args),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUpdateVisitorOptionalFields.mockResolvedValue({ error: null });
+});
+
+describe('OptionalFieldsModal', () => {
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(<OptionalFieldsModal isOpen={false} onComplete={vi.fn()} />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders heading, inputs, and buttons when open', () => {
+    render(<OptionalFieldsModal isOpen={true} onComplete={vi.fn()} />);
+
+    expect(screen.getByText('Tell me about yourself')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Company')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Role / Title')).toBeInTheDocument();
+    expect(screen.getByText('Skip')).toBeInTheDocument();
+    expect(screen.getByText('Continue')).toBeInTheDocument();
+  });
+
+  it('calls onComplete when Skip is clicked', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<OptionalFieldsModal isOpen={true} onComplete={onComplete} />);
+
+    await user.click(screen.getByText('Skip'));
+    expect(onComplete).toHaveBeenCalledOnce();
+    expect(mockUpdateVisitorOptionalFields).not.toHaveBeenCalled();
+  });
+
+  it('calls updateVisitorOptionalFields with field values on Continue', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<OptionalFieldsModal isOpen={true} onComplete={onComplete} />);
+
+    await user.type(screen.getByPlaceholderText('Company'), 'Acme Corp');
+    await user.type(screen.getByPlaceholderText('Role / Title'), 'Engineer');
+    await user.click(screen.getByText('Continue'));
+
+    expect(mockUpdateVisitorOptionalFields).toHaveBeenCalledWith('Acme Corp', 'Engineer');
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('calls onComplete with empty fields when Continue is clicked without input', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(<OptionalFieldsModal isOpen={true} onComplete={onComplete} />);
+
+    await user.click(screen.getByText('Continue'));
+
+    expect(mockUpdateVisitorOptionalFields).toHaveBeenCalledWith('', '');
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('shows Saving... text while submitting', async () => {
+    const user = userEvent.setup();
+    // Make the server action hang so we can observe the loading state
+    let resolveAction!: (value: { error: null }) => void;
+    mockUpdateVisitorOptionalFields.mockReturnValue(
+      new Promise((resolve) => {
+        resolveAction = resolve;
+      })
+    );
+
+    render(<OptionalFieldsModal isOpen={true} onComplete={vi.fn()} />);
+    await user.click(screen.getByText('Continue'));
+
+    expect(screen.getByText('Saving...')).toBeInTheDocument();
+
+    // Resolve to allow cleanup
+    resolveAction({ error: null });
+    await waitFor(() => {
+      expect(screen.getByText('Continue')).toBeInTheDocument();
+    });
+  });
+
+  it('shows toast error when server action fails', async () => {
+    const user = userEvent.setup();
+    mockUpdateVisitorOptionalFields.mockResolvedValue({ error: 'Server error' });
+    const onComplete = vi.fn();
+
+    render(<OptionalFieldsModal isOpen={true} onComplete={onComplete} />);
+    await user.click(screen.getByText('Continue'));
+
+    await waitFor(() => {
+      expect(mockToastError).toHaveBeenCalledWith('Failed to save details');
+    });
+    // onComplete is still called even on error (modal should close)
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+});

--- a/__tests__/unit/lib/queries.test.ts
+++ b/__tests__/unit/lib/queries.test.ts
@@ -1,0 +1,426 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createMockSupabaseClient, createChainMock } from '../../helpers/supabase-mock';
+import type { MockSupabaseClient } from '../../helpers/supabase-mock';
+import {
+  mockProfile,
+  mockStats,
+  mockExperiences,
+  mockCategories,
+  mockProjects,
+  mockSkillGroups,
+} from '../../helpers/admin-fixtures';
+
+// Mock the server client
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}));
+
+import { createClient } from '@/lib/supabase/server';
+import {
+  getProfile,
+  getProfileStats,
+  getNavLinks,
+  getCompanies,
+  getExperiences,
+  getProjectCategories,
+  getProjects,
+  getSkillGroups,
+  getProfileData,
+} from '@/lib/supabase/queries';
+
+let mockClient: MockSupabaseClient;
+
+// Save original env
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockClient = createMockSupabaseClient();
+  vi.mocked(createClient).mockResolvedValue(mockClient as never);
+  // Ensure Supabase env vars are set by default
+  process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://test.supabase.co';
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'test-anon-key';
+});
+
+afterEach(() => {
+  // Restore original env
+  process.env.NEXT_PUBLIC_SUPABASE_URL = originalEnv.NEXT_PUBLIC_SUPABASE_URL;
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = originalEnv.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+});
+
+// ─── isSupabaseConfigured (tested indirectly) ────────────────
+
+describe('Supabase not configured', () => {
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL;
+    delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  });
+
+  it('getProfile returns null when env vars are missing', async () => {
+    const result = await getProfile();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getProfileStats returns null when env vars are missing', async () => {
+    const result = await getProfileStats();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getNavLinks returns null when env vars are missing', async () => {
+    const result = await getNavLinks();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getCompanies returns null when env vars are missing', async () => {
+    const result = await getCompanies();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getExperiences returns null when env vars are missing', async () => {
+    const result = await getExperiences();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getProjectCategories returns null when env vars are missing', async () => {
+    const result = await getProjectCategories();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getProjects returns null when env vars are missing', async () => {
+    const result = await getProjects();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getSkillGroups returns null when env vars are missing', async () => {
+    const result = await getSkillGroups();
+    expect(result).toBeNull();
+    expect(createClient).not.toHaveBeenCalled();
+  });
+
+  it('getProfileData returns static fallback when env vars are missing', async () => {
+    const result = await getProfileData();
+    expect(result).toBeDefined();
+    expect(result.fullName).toBe('Laldingliana Tlau Vantawl');
+    expect(result.shortName).toBe('Lalding');
+    expect(result.jobTitle).toBe('Full-stack Tech Lead');
+    expect(createClient).not.toHaveBeenCalled();
+  });
+});
+
+// ─── getProfile ──────────────────────────────────────────────
+
+describe('getProfile', () => {
+  it('returns profile data on success', async () => {
+    mockClient._setTableResponse('profile', { data: mockProfile, error: null });
+    const result = await getProfile();
+    expect(result).toEqual(mockProfile);
+    expect(mockClient.from).toHaveBeenCalledWith('profile');
+  });
+
+  it('returns null on error', async () => {
+    mockClient._setTableResponse('profile', {
+      data: null,
+      error: { message: 'DB error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getProfile();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getProfile error:', 'DB error');
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── getProfileStats ─────────────────────────────────────────
+
+describe('getProfileStats', () => {
+  it('returns stats sorted by sort_order', async () => {
+    mockClient._setTableResponse('profile_stats', { data: mockStats, error: null });
+    const result = await getProfileStats();
+    expect(result).toEqual(mockStats);
+    expect(mockClient.from).toHaveBeenCalledWith('profile_stats');
+  });
+
+  it('returns null on error', async () => {
+    mockClient._setTableResponse('profile_stats', {
+      data: null,
+      error: { message: 'Stats error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getProfileStats();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getProfileStats error:', 'Stats error');
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── getNavLinks ─────────────────────────────────────────────
+
+describe('getNavLinks', () => {
+  const mockNavLinks = [
+    { id: 'nl-1', name: 'Home', hash: '#home', sort_order: 0 },
+    { id: 'nl-2', name: 'About', hash: '#about', sort_order: 1 },
+  ];
+
+  it('returns nav links sorted by sort_order', async () => {
+    mockClient._setTableResponse('nav_links', { data: mockNavLinks, error: null });
+    const result = await getNavLinks();
+    expect(result).toEqual(mockNavLinks);
+    expect(mockClient.from).toHaveBeenCalledWith('nav_links');
+  });
+
+  it('returns null on error', async () => {
+    mockClient._setTableResponse('nav_links', {
+      data: null,
+      error: { message: 'Nav error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getNavLinks();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getNavLinks error:', 'Nav error');
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── getCompanies ────────────────────────────────────────────
+
+describe('getCompanies', () => {
+  const mockCompanies = [
+    { id: 'co-1', name: 'Acme', logo_url: '/logos/acme.webp', sort_order: 0 },
+    { id: 'co-2', name: 'Globex', logo_url: '/logos/globex.webp', sort_order: 1 },
+  ];
+
+  it('returns companies sorted by sort_order', async () => {
+    mockClient._setTableResponse('companies', { data: mockCompanies, error: null });
+    const result = await getCompanies();
+    expect(result).toEqual(mockCompanies);
+    expect(mockClient.from).toHaveBeenCalledWith('companies');
+  });
+
+  it('returns null on error', async () => {
+    mockClient._setTableResponse('companies', {
+      data: null,
+      error: { message: 'Companies error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getCompanies();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getCompanies error:', 'Companies error');
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── getExperiences ──────────────────────────────────────────
+
+describe('getExperiences', () => {
+  it('returns experiences sorted by sort_order', async () => {
+    mockClient._setTableResponse('experiences', { data: mockExperiences, error: null });
+    const result = await getExperiences();
+    expect(result).toEqual(mockExperiences);
+    expect(mockClient.from).toHaveBeenCalledWith('experiences');
+  });
+
+  it('returns null on error', async () => {
+    mockClient._setTableResponse('experiences', {
+      data: null,
+      error: { message: 'Experiences error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getExperiences();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getExperiences error:', 'Experiences error');
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── getProjectCategories ────────────────────────────────────
+
+describe('getProjectCategories', () => {
+  it('returns categories sorted by sort_order', async () => {
+    mockClient._setTableResponse('project_categories', { data: mockCategories, error: null });
+    const result = await getProjectCategories();
+    expect(result).toEqual(mockCategories);
+    expect(mockClient.from).toHaveBeenCalledWith('project_categories');
+  });
+
+  it('returns null on error', async () => {
+    mockClient._setTableResponse('project_categories', {
+      data: null,
+      error: { message: 'Categories error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getProjectCategories();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getProjectCategories error:', 'Categories error');
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── getProjects ─────────────────────────────────────────────
+
+describe('getProjects', () => {
+  it('returns projects sorted by sort_order', async () => {
+    mockClient._setTableResponse('projects', { data: mockProjects, error: null });
+    const result = await getProjects();
+    expect(result).toEqual(mockProjects);
+    expect(mockClient.from).toHaveBeenCalledWith('projects');
+  });
+
+  it('returns null on error', async () => {
+    mockClient._setTableResponse('projects', {
+      data: null,
+      error: { message: 'Projects error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getProjects();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getProjects error:', 'Projects error');
+    consoleSpy.mockRestore();
+  });
+});
+
+// ─── getSkillGroups ──────────────────────────────────────────
+
+describe('getSkillGroups', () => {
+  const mockGroups = [
+    { id: 'sg-1', category: 'Frontend', sort_order: 0 },
+    { id: 'sg-2', category: 'Backend', sort_order: 1 },
+  ];
+
+  const mockSkills = [
+    { id: 'sk-1', name: 'React', group_id: 'sg-1', sort_order: 0 },
+    { id: 'sk-2', name: 'TypeScript', group_id: 'sg-1', sort_order: 1 },
+    { id: 'sk-3', name: 'Node.js', group_id: 'sg-2', sort_order: 0 },
+  ];
+
+  it('returns groups with nested skills', async () => {
+    // getSkillGroups calls from('skill_groups') then from('skills')
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: mockGroups, error: null }))
+      .mockReturnValueOnce(createChainMock({ data: mockSkills, error: null }));
+
+    const result = await getSkillGroups();
+    expect(result).toEqual([
+      {
+        ...mockGroups[0],
+        skills: [mockSkills[0], mockSkills[1]],
+      },
+      {
+        ...mockGroups[1],
+        skills: [mockSkills[2]],
+      },
+    ]);
+  });
+
+  it('returns null on groups fetch error', async () => {
+    mockClient.from.mockReturnValueOnce(
+      createChainMock({ data: null, error: { message: 'Groups error' } })
+    );
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getSkillGroups();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getSkillGroups error:', 'Groups error');
+    consoleSpy.mockRestore();
+  });
+
+  it('returns null on skills fetch error', async () => {
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: mockGroups, error: null }))
+      .mockReturnValueOnce(
+        createChainMock({ data: null, error: { message: 'Skills fetch error' } })
+      );
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getSkillGroups();
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith('getSkillGroups (skills) error:', 'Skills fetch error');
+    consoleSpy.mockRestore();
+  });
+
+  it('handles group with no matching skills', async () => {
+    const groupWithNoSkills = [{ id: 'sg-3', category: 'DevOps', sort_order: 2 }];
+    mockClient.from
+      .mockReturnValueOnce(createChainMock({ data: groupWithNoSkills, error: null }))
+      .mockReturnValueOnce(createChainMock({ data: mockSkills, error: null }));
+
+    const result = await getSkillGroups();
+    expect(result).toEqual([{ ...groupWithNoSkills[0], skills: [] }]);
+  });
+});
+
+// ─── getProfileData ──────────────────────────────────────────
+
+describe('getProfileData', () => {
+  it('maps DB profile to camelCase ProfileData', async () => {
+    mockClient._setTableResponse('profile', { data: mockProfile, error: null });
+    const result = await getProfileData();
+
+    expect(result.fullName).toBe(mockProfile.full_name);
+    expect(result.shortName).toBe(mockProfile.short_name);
+    expect(result.jobTitle).toBe(mockProfile.job_title);
+    expect(result.tagline).toBe(mockProfile.tagline);
+    expect(result.typewriterTitles).toEqual(mockProfile.typewriter_titles);
+    expect(result.email).toBe(mockProfile.email);
+    expect(result.phone).toBe(mockProfile.phone);
+    expect(result.location).toBe(mockProfile.location);
+    expect(result.linkedinUrl).toBe(mockProfile.linkedin_url);
+    expect(result.githubUrl).toBe(mockProfile.github_url);
+    expect(result.resumeUrl).toBe(mockProfile.resume_url);
+    expect(result.aboutTechStack).toBe(mockProfile.about_tech_stack);
+    expect(result.aboutCurrentFocus).toBe(mockProfile.about_current_focus);
+    expect(result.aboutBeyondCode).toBe(mockProfile.about_beyond_code);
+    expect(result.aboutExpertise).toEqual(mockProfile.about_expertise);
+    expect(result.footerText).toBe(mockProfile.footer_text);
+  });
+
+  it('handles null fields with defaults', async () => {
+    const profileWithNulls = {
+      ...mockProfile,
+      tagline: null,
+      phone: null,
+      location: null,
+      linkedin_url: null,
+      github_url: null,
+      resume_url: null,
+      about_tech_stack: null,
+      about_current_focus: null,
+      about_beyond_code: null,
+      about_expertise: null,
+      footer_text: null,
+    };
+    mockClient._setTableResponse('profile', { data: profileWithNulls, error: null });
+    const result = await getProfileData();
+
+    expect(result.tagline).toBe('');
+    expect(result.phone).toBe('');
+    expect(result.location).toBe('');
+    expect(result.linkedinUrl).toBe('');
+    expect(result.githubUrl).toBe('');
+    expect(result.resumeUrl).toBe('/lalding.pdf');
+    expect(result.aboutTechStack).toBe('');
+    expect(result.aboutCurrentFocus).toBe('');
+    expect(result.aboutBeyondCode).toBe('');
+    expect(result.aboutExpertise).toEqual([]);
+    expect(result.footerText).toBe('');
+  });
+
+  it('falls back to static profile on DB error', async () => {
+    mockClient._setTableResponse('profile', {
+      data: null,
+      error: { message: 'Connection error' },
+    });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const result = await getProfileData();
+
+    expect(result.fullName).toBe('Laldingliana Tlau Vantawl');
+    expect(result.shortName).toBe('Lalding');
+    consoleSpy.mockRestore();
+  });
+});

--- a/__tests__/unit/lib/queries.test.ts
+++ b/__tests__/unit/lib/queries.test.ts
@@ -33,6 +33,11 @@ let mockClient: MockSupabaseClient;
 // Save original env
 const originalEnv = { ...process.env };
 
+/** Spy on console.error, suppress output, and return the spy for assertions. */
+function suppressConsoleError() {
+  return vi.spyOn(console, 'error').mockImplementation(() => {});
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockClient = createMockSupabaseClient();
@@ -51,9 +56,16 @@ afterEach(() => {
 // ─── isSupabaseConfigured (tested indirectly) ────────────────
 
 describe('Supabase not configured', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
     delete process.env.NEXT_PUBLIC_SUPABASE_URL;
     delete process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
   });
 
   it('getProfile returns null when env vars are missing', async () => {
@@ -129,7 +141,7 @@ describe('getProfile', () => {
       data: null,
       error: { message: 'DB error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getProfile();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getProfile error:', 'DB error');
@@ -152,7 +164,7 @@ describe('getProfileStats', () => {
       data: null,
       error: { message: 'Stats error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getProfileStats();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getProfileStats error:', 'Stats error');
@@ -180,7 +192,7 @@ describe('getNavLinks', () => {
       data: null,
       error: { message: 'Nav error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getNavLinks();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getNavLinks error:', 'Nav error');
@@ -208,7 +220,7 @@ describe('getCompanies', () => {
       data: null,
       error: { message: 'Companies error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getCompanies();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getCompanies error:', 'Companies error');
@@ -231,7 +243,7 @@ describe('getExperiences', () => {
       data: null,
       error: { message: 'Experiences error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getExperiences();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getExperiences error:', 'Experiences error');
@@ -254,7 +266,7 @@ describe('getProjectCategories', () => {
       data: null,
       error: { message: 'Categories error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getProjectCategories();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getProjectCategories error:', 'Categories error');
@@ -277,7 +289,7 @@ describe('getProjects', () => {
       data: null,
       error: { message: 'Projects error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getProjects();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getProjects error:', 'Projects error');
@@ -323,7 +335,7 @@ describe('getSkillGroups', () => {
       createChainMock({ data: null, error: { message: 'Groups error' } })
     );
 
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getSkillGroups();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getSkillGroups error:', 'Groups error');
@@ -337,7 +349,7 @@ describe('getSkillGroups', () => {
         createChainMock({ data: null, error: { message: 'Skills fetch error' } })
       );
 
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getSkillGroups();
     expect(result).toBeNull();
     expect(consoleSpy).toHaveBeenCalledWith('getSkillGroups (skills) error:', 'Skills fetch error');
@@ -416,7 +428,7 @@ describe('getProfileData', () => {
       data: null,
       error: { message: 'Connection error' },
     });
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleSpy = suppressConsoleError();
     const result = await getProfileData();
 
     expect(result.fullName).toBe('Laldingliana Tlau Vantawl');

--- a/components/auth/login-modal.tsx
+++ b/components/auth/login-modal.tsx
@@ -29,6 +29,7 @@ export default function LoginModal({ isOpen, onClose }: LoginModalProps) {
             animate={{ opacity: 1 }}
             exit={{ opacity: 0 }}
             onClick={onClose}
+            data-testid="backdrop"
           />
 
           <motion.div

--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -894,7 +894,28 @@ The following tests were built alongside their respective features:
 
 **Follows:** existing component test patterns in `__tests__/components/admin/`.
 
-### 6B Status: PENDING
+### 6B Implementation Notes
+
+- Created `__tests__/components/auth/login-modal.test.tsx` with 9 tests:
+  - Renders nothing when `isOpen` is false (empty container)
+  - Renders heading ("Sign in to download"), all 3 social login buttons, and Cancel button
+  - Calls `onClose` when Cancel button is clicked
+  - Calls `onClose` when backdrop overlay is clicked
+  - Calls `signInWithProvider` with correct provider string for each button (`'google'`, `'github'`, `'linkedin_oidc'`)
+  - Stores `pendingAction: 'download_resume'` in localStorage before OAuth redirect
+- Mocks `@/context/auth-context` (`useAuth`) to provide a mock `signInWithProvider` function.
+- Created `__tests__/components/auth/optional-fields-modal.test.tsx` with 7 tests:
+  - Renders nothing when `isOpen` is false
+  - Renders heading, Company/Role inputs, Skip and Continue buttons
+  - Calls `onComplete` without calling server action when Skip is clicked
+  - Calls `updateVisitorOptionalFields` with typed values and then `onComplete` on Continue
+  - Handles empty fields (submits empty strings)
+  - Shows "Saving..." loading text while server action is pending
+  - Shows toast error on server action failure, still calls `onComplete`
+- Mocks `@/actions/resume` (`updateVisitorOptionalFields`) and `react-hot-toast` (`toast.error`).
+- All 251 tests pass (16 new + 235 existing). Lint, format, and build all pass.
+
+### 6B Status: COMPLETE
 
 ---
 

--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -932,7 +932,20 @@ The following tests were built alongside their respective features:
 
 **Note:** Requires `E2E_VISITOR_EMAIL` / `E2E_VISITOR_PASSWORD` env vars or mocked auth state. May need a test visitor account in Supabase.
 
-### 6C Status: PENDING
+### 6C Implementation Notes
+
+- Created `e2e/resume-download.spec.ts` with 6 Playwright tests covering the unauthenticated resume download flow:
+  - "Download Resume" button is visible in the intro section
+  - Clicking "Download Resume" opens the LoginModal for unauthenticated users
+  - LoginModal displays all three social login buttons (Google, GitHub, LinkedIn)
+  - LoginModal can be closed via the Cancel button
+  - LoginModal can be closed by clicking the backdrop overlay
+  - "Download Resume" button is enabled and not in downloading state initially
+- Test runs on all three browser projects (chromium, firefox, webkit) — it doesn't match the `admin-*` ignore pattern.
+- **Limitation:** The full authenticated flow (OAuth login → OptionalFieldsModal → download trigger) cannot be tested in E2E without real OAuth credentials or a test visitor account. Visitor auth uses social login only (no email/password), so there's no way to programmatically authenticate a visitor like the admin auth setup does. The unauthenticated path (modal appearance, interactions, dismissal) is fully covered. The authenticated download logic is covered by unit tests (6A: `downloadResume` server action, 6B: `OptionalFieldsModal` component).
+- All 6 E2E tests pass on chromium. All 251 unit tests pass. Lint and format clean.
+
+### 6C Status: COMPLETE
 
 ---
 

--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -962,7 +962,21 @@ The following tests were built alongside their respective features:
 
 **Depends on:** admin auth setup (`e2e/auth.setup.ts`), saved auth state.
 
-### 6D Status: PENDING
+### 6D Implementation Notes
+
+- Created `e2e/admin-public-sync.spec.ts` with 1 comprehensive test that covers the full round-trip:
+  1. Reads the current profile tagline from `/admin/profile`
+  2. Edits it to a unique timestamped test value
+  3. Saves and waits for confirmation
+  4. Navigates to the public homepage `/` and verifies the new tagline is visible
+  5. Reverts the tagline to its original value via the admin editor
+  6. Verifies the public homepage shows the restored original value
+- Uses `test.skip(!hasAuth, ...)` to gracefully skip when `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` are not set — consistent with all other `admin-*` E2E tests.
+- Filename matches `admin-*` pattern so it runs in the `admin` Playwright project with saved auth state from `auth.setup.ts`.
+- Test is self-cleaning: always reverts the change regardless of test outcome within the test flow.
+- Skips as expected locally (no admin credentials). Lint and format clean.
+
+### 6D Status: COMPLETE
 
 ---
 

--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -1000,7 +1000,21 @@ The following tests were built alongside their respective features:
 
 4. **Document contributor setup** — note in `.env.example` or README that fork contributors without Supabase access will see a logged warning and the build will use static data fallback.
 
-### 6E Status: PENDING
+### 6E Implementation Notes
+
+- `.env.example` already had Supabase env vars from Phase 1. Updated with descriptive comments explaining fallback behavior, and added optional `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` entries for E2E testing.
+- Created `scripts/validate-supabase.ts` — uses `@supabase/supabase-js` directly (not the SSR server client) to avoid cookie dependencies. Queries `profile` table with `.select('id').limit(1)`. Exits 0 on success or when env vars are missing (fallback is acceptable), exits 1 on connection failure.
+- Added `"validate-supabase"` npm script to `package.json` (`npx tsx scripts/validate-supabase.ts`).
+- Updated `.github/workflows/ci.yml`:
+  - Added top-level comment documenting that fork contributors without Supabase secrets will use static data fallback.
+  - **Build job**: Added `validate-supabase` step before `npm run build`, with `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` from secrets. Build step also receives these env vars.
+  - **E2E job**: Added Supabase env vars + `E2E_ADMIN_EMAIL` / `E2E_ADMIN_PASSWORD` from secrets to the E2E test run step.
+- Verified both script paths: exits 0 with warning when env vars are missing, exits 0 with success message when Supabase is configured and reachable.
+- All checks pass: lint, format, build.
+
+### 6E Status: COMPLETE
+
+### Phase 6 Status: COMPLETE
 
 ---
 

--- a/e2e/admin-public-sync.spec.ts
+++ b/e2e/admin-public-sync.spec.ts
@@ -16,22 +16,26 @@ test.describe('Admin Edit → Public Site Verification', () => {
 
     // ── Step 2: Change the tagline to a unique test value ──
     const testTagline = `E2E sync test ${Date.now()}`;
-    await taglineInput.fill(testTagline);
-    await page.getByRole('button', { name: 'Save General Info' }).click();
 
-    // Wait for save confirmation
-    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 10000 });
+    try {
+      await taglineInput.fill(testTagline);
+      await page.getByRole('button', { name: 'Save General Info' }).click();
 
-    // ── Step 3: Navigate to public homepage and verify the change ──
-    await page.goto('/');
-    await expect(page.getByText(testTagline)).toBeVisible({ timeout: 10000 });
+      // Wait for save confirmation
+      await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 10000 });
 
-    // ── Step 4: Revert the tagline to its original value ──
-    await page.goto('/admin/profile');
-    await expect(taglineInput).toBeVisible();
-    await taglineInput.fill(originalTagline);
-    await page.getByRole('button', { name: 'Save General Info' }).click();
-    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 10000 });
+      // ── Step 3: Navigate to public homepage and verify the change ──
+      await page.goto('/');
+      await expect(page.getByText(testTagline)).toBeVisible({ timeout: 10000 });
+    } finally {
+      // ── Step 4: Always revert the tagline to its original value ──
+      await page.goto('/admin/profile');
+      const input = page.locator('#tagline');
+      await expect(input).toBeVisible();
+      await input.fill(originalTagline);
+      await page.getByRole('button', { name: 'Save General Info' }).click();
+      await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 10000 });
+    }
 
     // ── Step 5: Verify the public homepage shows the original value ──
     await page.goto('/');

--- a/e2e/admin-public-sync.spec.ts
+++ b/e2e/admin-public-sync.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+const hasAuth = !!(process.env.E2E_ADMIN_EMAIL && process.env.E2E_ADMIN_PASSWORD);
+
+test.describe('Admin Edit → Public Site Verification', () => {
+  test.skip(!hasAuth, 'Requires E2E_ADMIN_EMAIL and E2E_ADMIN_PASSWORD');
+
+  test('editing profile tagline is reflected on the public homepage', async ({ page }) => {
+    // ── Step 1: Read the current tagline from the admin profile page ──
+    await page.goto('/admin/profile');
+    await expect(page.getByRole('heading', { name: 'Profile Editor', level: 1 })).toBeVisible();
+
+    const taglineInput = page.locator('#tagline');
+    await expect(taglineInput).toBeVisible();
+    const originalTagline = await taglineInput.inputValue();
+
+    // ── Step 2: Change the tagline to a unique test value ──
+    const testTagline = `E2E sync test ${Date.now()}`;
+    await taglineInput.fill(testTagline);
+    await page.getByRole('button', { name: 'Save General Info' }).click();
+
+    // Wait for save confirmation
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 10000 });
+
+    // ── Step 3: Navigate to public homepage and verify the change ──
+    await page.goto('/');
+    await expect(page.getByText(testTagline)).toBeVisible({ timeout: 10000 });
+
+    // ── Step 4: Revert the tagline to its original value ──
+    await page.goto('/admin/profile');
+    await expect(taglineInput).toBeVisible();
+    await taglineInput.fill(originalTagline);
+    await page.getByRole('button', { name: 'Save General Info' }).click();
+    await expect(page.getByText(/saved/i)).toBeVisible({ timeout: 10000 });
+
+    // ── Step 5: Verify the public homepage shows the original value ──
+    await page.goto('/');
+    await expect(page.getByText(originalTagline)).toBeVisible({ timeout: 10000 });
+  });
+});

--- a/e2e/resume-download.spec.ts
+++ b/e2e/resume-download.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Resume Download Flow', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('Download Resume button is visible in the intro section', async ({ page }) => {
+    const downloadButton = page.getByRole('button', { name: /download resume/i });
+    await expect(downloadButton).toBeVisible();
+  });
+
+  test('clicking Download Resume opens the login modal for unauthenticated users', async ({
+    page,
+  }) => {
+    const downloadButton = page.getByRole('button', { name: /download resume/i });
+    await downloadButton.click();
+
+    // Login modal should appear with heading
+    await expect(page.getByText('Sign in to download')).toBeVisible();
+  });
+
+  test('login modal displays all three social login buttons', async ({ page }) => {
+    await page.getByRole('button', { name: /download resume/i }).click();
+
+    await expect(page.getByRole('button', { name: /continue with google/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /continue with github/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /continue with linkedin/i })).toBeVisible();
+  });
+
+  test('login modal can be closed with the Cancel button', async ({ page }) => {
+    await page.getByRole('button', { name: /download resume/i }).click();
+    await expect(page.getByText('Sign in to download')).toBeVisible();
+
+    await page.getByRole('button', { name: /cancel/i }).click();
+
+    // Modal should be dismissed
+    await expect(page.getByText('Sign in to download')).not.toBeVisible();
+  });
+
+  test('login modal can be closed by clicking the backdrop', async ({ page }) => {
+    await page.getByRole('button', { name: /download resume/i }).click();
+    await expect(page.getByText('Sign in to download')).toBeVisible();
+
+    // Click the backdrop overlay (the fixed inset-0 element behind the modal)
+    // Use force: true because the backdrop is behind the modal content
+    const backdrop = page.locator('div.fixed.inset-0').first();
+    await backdrop.click({ force: true });
+
+    await expect(page.getByText('Sign in to download')).not.toBeVisible();
+  });
+
+  test('Download Resume button is not in downloading state initially', async ({ page }) => {
+    const downloadButton = page.getByRole('button', { name: /download resume/i });
+    await expect(downloadButton).toBeEnabled();
+    await expect(downloadButton).not.toContainText('Downloading');
+  });
+});

--- a/e2e/resume-download.spec.ts
+++ b/e2e/resume-download.spec.ts
@@ -42,10 +42,10 @@ test.describe('Resume Download Flow', () => {
     await page.getByRole('button', { name: /download resume/i }).click();
     await expect(page.getByText('Sign in to download')).toBeVisible();
 
-    // Click the backdrop overlay (the fixed inset-0 element behind the modal)
-    // Use force: true because the backdrop is behind the modal content
-    const backdrop = page.locator('div.fixed.inset-0').first();
-    await backdrop.click({ force: true });
+    // Click outside the modal content area to hit the backdrop overlay.
+    // The modal is centered horizontally and positioned at top 20%, so
+    // clicking the top-left corner (10, 10) reliably hits the backdrop.
+    await page.mouse.click(10, 10);
 
     await expect(page.getByText('Sign in to download')).not.toBeVisible();
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "prettier": "^3.8.1",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "shadcn": "^3.8.4",
+        "tsx": "^4.21.0",
         "tw-animate-css": "^1.4.0",
         "vitest": "^4.0.18"
       }
@@ -14228,6 +14229,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tw-animate-css": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
-    "seed": "npx tsx lib/supabase/seed.ts",
-    "setup-admin": "npx tsx lib/supabase/setup-admin.ts",
-    "validate-supabase": "npx tsx scripts/validate-supabase.ts"
+    "seed": "tsx lib/supabase/seed.ts",
+    "setup-admin": "tsx lib/supabase/setup-admin.ts",
+    "validate-supabase": "tsx scripts/validate-supabase.ts"
   },
   "dependencies": {
     "@react-email/components": "^1.0.7",
@@ -69,6 +69,7 @@
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "shadcn": "^3.8.4",
+    "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "vitest": "^4.0.18"
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "seed": "npx tsx lib/supabase/seed.ts",
-    "setup-admin": "npx tsx lib/supabase/setup-admin.ts"
+    "setup-admin": "npx tsx lib/supabase/setup-admin.ts",
+    "validate-supabase": "npx tsx scripts/validate-supabase.ts"
   },
   "dependencies": {
     "@react-email/components": "^1.0.7",

--- a/scripts/validate-supabase.ts
+++ b/scripts/validate-supabase.ts
@@ -1,0 +1,38 @@
+/**
+ * Validates Supabase connection by attempting a simple query.
+ * Exits with code 0 on success, 1 on failure.
+ *
+ * Usage: npx tsx scripts/validate-supabase.ts
+ *
+ * If NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY are not set,
+ * logs a warning and exits with code 0 (build will use static data fallback).
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+if (!url || !anonKey) {
+  console.warn(
+    '⚠️  Supabase env vars not set (NEXT_PUBLIC_SUPABASE_URL, NEXT_PUBLIC_SUPABASE_ANON_KEY).'
+  );
+  console.warn('   Build will use static data fallback.');
+  process.exit(0);
+}
+
+const supabase = createClient(url, anonKey);
+
+async function validate() {
+  const { error } = await supabase.from('profile').select('id').limit(1);
+
+  if (error) {
+    console.error('❌ Supabase connection failed:', error.message);
+    process.exit(1);
+  }
+
+  console.log('✅ Supabase connection verified.');
+  process.exit(0);
+}
+
+validate();


### PR DESCRIPTION
## Summary
- **Phase 6A**: 30 unit tests for all 9 data fetching functions in `lib/supabase/queries.ts` — env-guard fallback, error handling, successful queries, skill group nesting, ProfileData mapping
- **Phase 6B**: 16 component tests for `LoginModal` (9) and `OptionalFieldsModal` (7) — render/hide, social login buttons, modal dismissal, form submission, loading/error states
- **Phase 6C**: 6 Playwright E2E tests for the resume download flow — button visibility, login modal interactions, backdrop/cancel dismissal
- **Phase 6D**: 1 comprehensive E2E test verifying admin profile edits are reflected on the public homepage (self-cleaning, reverts changes)
- **Phase 6E**: Supabase connection validation script (`scripts/validate-supabase.ts`), CI workflow updates with Supabase/E2E env vars, `.env.example` documentation

## Test plan
- [x] All 251 unit/component tests pass (`npm run test:run`)
- [x] All new E2E tests pass on Chromium (`npx playwright test --project=chromium`)
- [x] Admin E2E tests skip gracefully without credentials
- [x] `validate-supabase` script exits 0 with warning when env vars missing
- [x] `validate-supabase` script exits 0 with success when Supabase is reachable
- [x] ESLint passes (`npm run lint`)
- [x] Prettier passes (`npm run format:check`)
- [x] Production build succeeds (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume download with social sign-in (Google, GitHub, LinkedIn) and an admin panel whose edits sync to the public site.

* **Tests**
  * Added comprehensive unit, component, and end-to-end tests covering auth, admin flows, and resume download.

* **Documentation**
  * Expanded CMS, testing, and deployment plan with detailed Phase and CI guidance.

* **Chores**
  * CI and environment validation improvements and a new Supabase validation script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->