### PR TITLE
Fix contact form email delivery and add sender name

### DIFF
--- a/actions/sendEmail.ts
+++ b/actions/sendEmail.ts
@@ -33,17 +33,14 @@ export const sendEmail = async (formData: FormData) => {
   }
 
   // Normalize: trim whitespace and strip CR/LF to prevent email header injection
-  const name = validateString(senderName, 200)
-    ? senderName.trim().replace(/[\r\n]/g, '')
-    : undefined;
-  const sanitizedName = name || undefined;
-  const subject = sanitizedName
-    ? `Message from ${sanitizedName} via Lalding's Portfolio`
+  const name =
+    (validateString(senderName, 200) && senderName.trim().replace(/[\r\n]/g, '')) || undefined;
+  const subject = name
+    ? `Message from ${name} via Lalding's Portfolio`
     : "Message from Lalding's Portfolio Contact form";
 
-  let data;
   try {
-    data = await resend.emails.send({
+    const { data, error } = await resend.emails.send({
       from: 'Laldings Portfolio Contact Form <onboarding@resend.dev>',
       to: 'laldingliana.tv@gmail.com',
       subject,
@@ -51,22 +48,20 @@ export const sendEmail = async (formData: FormData) => {
       react: React.createElement(ContactFormEmail, {
         message: message,
         senderEmail: senderEmail,
-        senderName: sanitizedName,
+        senderName: name,
       }),
     });
 
-    if (data.error) {
-      console.error('Resend API error:', data.error);
-      return { error: data.error.message };
+    if (error) {
+      console.error('Resend API error:', error);
+      return { error: error.message };
     }
+
+    return { data };
   } catch (error: unknown) {
     console.error('Email send failed:', error);
     return {
       error: getErrorMessage(error),
     };
   }
-
-  return {
-    data,
-  };
 };

--- a/actions/sendEmail.ts
+++ b/actions/sendEmail.ts
@@ -16,6 +16,7 @@ if (!RESEND_API_KEY) {
 const resend = new Resend(RESEND_API_KEY);
 
 export const sendEmail = async (formData: FormData) => {
+  const senderName = formData.get('senderName');
   const senderEmail = formData.get('senderEmail');
   const message = formData.get('message');
 
@@ -31,19 +32,31 @@ export const sendEmail = async (formData: FormData) => {
     };
   }
 
+  const name = validateString(senderName, 200) ? senderName : undefined;
+  const subject = name
+    ? `Message from ${name} via Lalding's Portfolio`
+    : "Message from Lalding's Portfolio Contact form";
+
   let data;
   try {
     data = await resend.emails.send({
       from: 'Laldings Portfolio Contact Form <onboarding@resend.dev>',
       to: 'laldingliana.tv@gmail.com',
-      subject: "Message from Lalding's Portfolio's Contact form",
+      subject,
       replyTo: senderEmail,
       react: React.createElement(ContactFormEmail, {
         message: message,
         senderEmail: senderEmail,
+        senderName: name,
       }),
     });
+
+    if (data.error) {
+      console.error('Resend API error:', data.error);
+      return { error: data.error.message };
+    }
   } catch (error: unknown) {
+    console.error('Email send failed:', error);
     return {
       error: getErrorMessage(error),
     };

--- a/actions/sendEmail.ts
+++ b/actions/sendEmail.ts
@@ -32,9 +32,13 @@ export const sendEmail = async (formData: FormData) => {
     };
   }
 
-  const name = validateString(senderName, 200) ? senderName : undefined;
-  const subject = name
-    ? `Message from ${name} via Lalding's Portfolio`
+  // Normalize: trim whitespace and strip CR/LF to prevent email header injection
+  const name = validateString(senderName, 200)
+    ? senderName.trim().replace(/[\r\n]/g, '')
+    : undefined;
+  const sanitizedName = name || undefined;
+  const subject = sanitizedName
+    ? `Message from ${sanitizedName} via Lalding's Portfolio`
     : "Message from Lalding's Portfolio Contact form";
 
   let data;
@@ -47,7 +51,7 @@ export const sendEmail = async (formData: FormData) => {
       react: React.createElement(ContactFormEmail, {
         message: message,
         senderEmail: senderEmail,
-        senderName: name,
+        senderName: sanitizedName,
       }),
     });
 

--- a/email/contact-form-email.tsx
+++ b/email/contact-form-email.tsx
@@ -15,9 +15,14 @@ import { Tailwind } from '@react-email/tailwind';
 type ContactFormEmailProps = {
   message: string;
   senderEmail: string;
+  senderName?: string;
 };
 
-export default function ContactFormEmail({ message, senderEmail }: ContactFormEmailProps) {
+export default function ContactFormEmail({
+  message,
+  senderEmail,
+  senderName,
+}: ContactFormEmailProps) {
   return (
     <Html>
       <Head />
@@ -31,7 +36,8 @@ export default function ContactFormEmail({ message, senderEmail }: ContactFormEm
               </Heading>
               <Text>{message}</Text>
               <Hr />
-              <Text>The sender's email is: {senderEmail}</Text>
+              {senderName && <Text>From: {senderName}</Text>}
+              <Text>Email: {senderEmail}</Text>
             </Section>
           </Container>
         </Body>


### PR DESCRIPTION
## Summary
- Read `senderName` from form data — was collected by the form but never passed to the server action or email template
- Personalize email subject with sender name (e.g., "Message from John via Lalding's Portfolio")
- Include sender name in the email template body ("From: John")
- Handle Resend API-level errors (`data.error`) that were previously silently ignored — now surfaces the error message to the user via toast
- Add `console.error` logging for both API errors and exceptions to help diagnose delivery issues in Vercel function logs

## Test plan
- [ ] Submit contact form with name, email, and message on the deployed site
- [ ] Verify toast shows "Email sent successfully!"
- [ ] Verify email arrives at laldingliana.tv@gmail.com with sender name in subject and body
- [ ] Submit without a name — verify generic subject line and no "From:" line in email
- [ ] Check Vercel function logs for any "Resend API error:" messages if email doesn't arrive
- [ ] If `onboarding@resend.dev` sender causes delivery issues, verify custom domain in Resend dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Sender name from the contact form is now captured and displayed in email messages, giving recipients better context.
- Email subject lines are now dynamically generated based on sender information.

**Bug Fixes**
- Significantly improved error handling with detailed structured logging for failed email submissions.
- Enhanced form data validation and sanitization to ensure better reliability and prevent edge case issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->