### PR TITLE
Switch contact form recipient to pateatlau@gmail.com

### DIFF
--- a/actions/sendEmail.ts
+++ b/actions/sendEmail.ts
@@ -43,7 +43,7 @@ export const sendEmail = async (formData: FormData) => {
   try {
     const { data, error } = await resend.emails.send({
       from: "Lalding's Portfolio <noreply@lalding.in>",
-      to: 'laldingliana.tv@gmail.com',
+      to: 'pateatlau@gmail.com',
       subject,
       replyTo: senderEmail,
       react: React.createElement(ContactFormEmail, {


### PR DESCRIPTION
Emails from the newly verified lalding.in domain are being silently filtered by Gmail for laldingliana.tv@gmail.com due to lack of domain reputation. Switching to pateatlau@gmail.com where delivery is confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email recipient configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->