### PR TITLE
Add JD Optimization feature (8I + 8J) to resume builder plan

### DIFF
--- a/docs/cms-and-auth-plan.md
+++ b/docs/cms-and-auth-plan.md
@@ -1265,7 +1265,7 @@ Before implementation can begin, complete these steps:
 
 ## Phase 8: Resume Builder
 
-Full architecture design, data model, template system, PDF generation pipeline, and implementation sub-tasks (8A–8H) are documented in a separate file:
+Full architecture design, data model, template system, PDF generation pipeline, JD optimization, and implementation sub-tasks (8A–8J) are documented in a separate file:
 
 **[`docs/resume-builder-plan.md`](./resume-builder-plan.md)**
 


### PR DESCRIPTION
- Add job_description, jd_keywords, jd_coverage_score, jd_analysis columns to resume_configs table schema
- Add JdAnalysisResult and JdSuggestion TypeScript types
- Add sub-task 8I: JD Analysis Engine — LLM-powered keyword extraction, coverage scoring against CMS data, section emphasis suggestions
- Add sub-task 8J: JD Optimization UI — paste JD, keyword chips, coverage score bar, apply suggestions to composer
- Feature is optional: guarded by RESUME_BUILDER_LLM_API_KEY env var, hidden when not configured
- Update main plan reference from 8A–8H to 8A–8J

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Job Description (JD) Optimization to the resume builder: JD analysis, coverage scoring, and item-specific suggestions with apply/clear UX and Composer integration; feature gated by LLM API key.

* **Documentation**
  * Updated planning and implementation notes to document JD optimization, scoring/visualization, PII/retention considerations, and admin wipe behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->