### PR TITLE
fix: resume download opens in new tab and guard empty image src

### DIFF
--- a/components/companies-slider.tsx
+++ b/components/companies-slider.tsx
@@ -72,17 +72,19 @@ function CompaniesSlider({ companies }: { companies: CompanyData[] }) {
   return (
     <div className="container mt-10 hidden pt-2 pb-0 sm:block">
       <Slider {...settings}>
-        {companies.map((company) => (
-          <div key={company.name}>
-            <Image
-              src={company.logo}
-              alt={company.name}
-              height={80}
-              width={80}
-              className="h-24 w-32 rounded-xs opacity-60 grayscale transition-all duration-300 hover:opacity-100 hover:grayscale-0"
-            />
-          </div>
-        ))}
+        {companies
+          .filter((company) => company.logo)
+          .map((company) => (
+            <div key={company.name}>
+              <Image
+                src={company.logo}
+                alt={company.name}
+                height={80}
+                width={80}
+                className="h-24 w-32 rounded-xs opacity-60 grayscale transition-all duration-300 hover:opacity-100 hover:grayscale-0"
+              />
+            </div>
+          ))}
       </Slider>
     </div>
   );

--- a/components/experience.tsx
+++ b/components/experience.tsx
@@ -64,13 +64,15 @@ export default function Experience({
                     {item.company}
                   </p>
                 </div>
-                <Image
-                  src={item.companyLogo}
-                  alt={`${item.company} company logo`}
-                  height={50}
-                  width={50}
-                  className="h-10 w-10 shrink-0 rounded-lg sm:h-[50px] sm:w-[50px]"
-                />
+                {item.companyLogo && (
+                  <Image
+                    src={item.companyLogo}
+                    alt={`${item.company} company logo`}
+                    height={50}
+                    width={50}
+                    className="h-10 w-10 shrink-0 rounded-lg sm:h-[50px] sm:w-[50px]"
+                  />
+                )}
               </div>
               <p className="text-muted-foreground mt-1! font-normal!">{item.description}</p>
             </VerticalTimelineElement>

--- a/lib/hooks.ts
+++ b/lib/hooks.ts
@@ -39,8 +39,13 @@ export function useResumeDownload() {
   const [isDownloading, setIsDownloading] = useState(false);
 
   const triggerDownload = useCallback(async () => {
-    // Open window synchronously during user gesture to avoid popup blockers
-    const popup = window.open('about:blank', '_blank', 'noopener,noreferrer');
+    // Open window synchronously during user gesture to avoid popup blockers.
+    // Cannot use 'noopener' here — it causes window.open to return null,
+    // which prevents us from navigating the popup after the async call.
+    const popup = window.open('about:blank', '_blank');
+    if (popup) {
+      popup.opener = null; // sever opener reference for security
+    }
 
     setIsDownloading(true);
     const result = await downloadResume();


### PR DESCRIPTION
- Fix window.open returning null due to 'noopener' flag — open without noopener, then sever opener reference manually via popup.opener = null
- Guard <Image> render in Experience and CompaniesSlider to skip entries with empty company_logo_url, preventing Next.js empty src warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Company logos in the companies slider and experience timeline sections now render conditionally, displaying only when logos are available to prevent visual inconsistencies.

* **Refactor**
  * Enhanced security controls for popup windows with improved opener reference management to ensure safer handling of external links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->